### PR TITLE
Update travis to include tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,8 @@ android:
   - build-tools-24.0.2
   - android-24
   - extra-android-m2repository
-  licenses:
-    - 'android-sdk-preview-license-52d11cd2'
-    - 'android-sdk-license-.+'
 script:
-- "./gradlew clean build --stacktrace"
+- ./gradlew check --stacktrace
 branches:
   except:
   - gh-pages


### PR DESCRIPTION
Updated the script to run the tests. 
Unnecessary `./gradlew clean` is removed. 
"Licenses" part is also removed. It is only needed for special licenses. The default license is automatically approved by Travis.