### PR TITLE
FileSystem factory

### DIFF
--- a/app/src/main/java/com/nytimes/android/sample/activity/PersistingStoreActivity.java
+++ b/app/src/main/java/com/nytimes/android/sample/activity/PersistingStoreActivity.java
@@ -6,11 +6,10 @@ import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.Toolbar;
 import android.widget.Toast;
-
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.nytimes.android.external.fs.SourcePersister;
-import com.nytimes.android.external.fs.impl.FileSystemImpl;
+import com.nytimes.android.external.fs.filesystem.FileSystemFactory;
 import com.nytimes.android.external.store.base.Store;
 import com.nytimes.android.external.store.base.impl.BarCode;
 import com.nytimes.android.external.store.base.impl.ParsingStoreBuilder;
@@ -23,10 +22,8 @@ import com.nytimes.android.sample.data.model.Post;
 import com.nytimes.android.sample.data.model.RedditData;
 import com.nytimes.android.sample.data.remote.Api;
 import com.nytimes.android.sample.reddit.PostAdapter;
-
 import java.io.IOException;
 import java.util.List;
-
 import okio.BufferedSource;
 import retrofit2.GsonConverterFactory;
 import retrofit2.Retrofit;
@@ -100,7 +97,7 @@ public class PersistingStoreActivity extends AppCompatActivity {
     }
 
     private SourcePersister persister() throws IOException {
-        return new SourcePersister(new FileSystemImpl(getApplicationContext().getCacheDir()));
+        return new SourcePersister(FileSystemFactory.create(getApplicationContext().getCacheDir()));
     }
 
     private Observable<BufferedSource> fetcher(BarCode barCode) {

--- a/filesystem/src/main/java/com/nytimes/android/external/fs/FileSystemFactory.java
+++ b/filesystem/src/main/java/com/nytimes/android/external/fs/FileSystemFactory.java
@@ -1,0 +1,22 @@
+package com.nytimes.android.external.fs;
+
+import com.nytimes.android.external.fs.impl.FileSystemImpl;
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Factory for {@link FileSystem}.
+ */
+public class FileSystemFactory {
+
+  /**
+   * Creates new instance of {@link FileSystemImpl}.
+   *
+   * @param root root directory.
+   * @return new instance of {@link FileSystemImpl}.
+   * @throws IOException
+   */
+  public static FileSystem create(File root) throws IOException {
+    return new FileSystemImpl(root);
+  }
+}

--- a/filesystem/src/main/java/com/nytimes/android/external/fs/SourceFileReader.java
+++ b/filesystem/src/main/java/com/nytimes/android/external/fs/SourceFileReader.java
@@ -1,5 +1,6 @@
 package com.nytimes.android.external.fs;
 
+import com.nytimes.android.external.fs.filesystem.FileSystem;
 import com.nytimes.android.external.store.base.DiskRead;
 import com.nytimes.android.external.store.base.impl.BarCode;
 

--- a/filesystem/src/main/java/com/nytimes/android/external/fs/SourceFileWriter.java
+++ b/filesystem/src/main/java/com/nytimes/android/external/fs/SourceFileWriter.java
@@ -1,5 +1,6 @@
 package com.nytimes.android.external.fs;
 
+import com.nytimes.android.external.fs.filesystem.FileSystem;
 import com.nytimes.android.external.store.base.DiskWrite;
 import com.nytimes.android.external.store.base.impl.BarCode;
 

--- a/filesystem/src/main/java/com/nytimes/android/external/fs/SourcePersister.java
+++ b/filesystem/src/main/java/com/nytimes/android/external/fs/SourcePersister.java
@@ -2,6 +2,7 @@ package com.nytimes.android.external.fs;
 
 import android.support.annotation.NonNull;
 
+import com.nytimes.android.external.fs.filesystem.FileSystem;
 import com.nytimes.android.external.store.base.Persister;
 import com.nytimes.android.external.store.base.impl.BarCode;
 

--- a/filesystem/src/main/java/com/nytimes/android/external/fs/filesystem/BreadthFirstFileTreeIterator.java
+++ b/filesystem/src/main/java/com/nytimes/android/external/fs/filesystem/BreadthFirstFileTreeIterator.java
@@ -1,4 +1,4 @@
-package com.nytimes.android.external.fs.impl;
+package com.nytimes.android.external.fs.filesystem;
 
 /*
  * Copyright 2004-2007 the original author or authors.
@@ -31,7 +31,7 @@ import java.util.NoSuchElementException;
  @since 1.1
  */
 
-public class BreadthFirstFileTreeIterator implements Iterator{
+class BreadthFirstFileTreeIterator implements Iterator{
 
     private File root;
     private int currentIndex = 0;
@@ -45,7 +45,7 @@ public class BreadthFirstFileTreeIterator implements Iterator{
      @param root The root directory
      */
 
-    public BreadthFirstFileTreeIterator(File root){
+    BreadthFirstFileTreeIterator(File root){
         this.root = root;
         this.currentList = root.listFiles();
         this.directories = new Stack();

--- a/filesystem/src/main/java/com/nytimes/android/external/fs/filesystem/FSFile.java
+++ b/filesystem/src/main/java/com/nytimes/android/external/fs/filesystem/FSFile.java
@@ -1,4 +1,4 @@
-package com.nytimes.android.external.fs.impl;
+package com.nytimes.android.external.fs.filesystem;
 
 import com.nytimes.android.external.fs.Util;
 

--- a/filesystem/src/main/java/com/nytimes/android/external/fs/filesystem/FileSystem.java
+++ b/filesystem/src/main/java/com/nytimes/android/external/fs/filesystem/FileSystem.java
@@ -1,4 +1,4 @@
-package com.nytimes.android.external.fs;
+package com.nytimes.android.external.fs.filesystem;
 
 import java.io.File;
 import java.io.FileNotFoundException;

--- a/filesystem/src/main/java/com/nytimes/android/external/fs/filesystem/FileSystemFactory.java
+++ b/filesystem/src/main/java/com/nytimes/android/external/fs/filesystem/FileSystemFactory.java
@@ -1,6 +1,5 @@
-package com.nytimes.android.external.fs;
+package com.nytimes.android.external.fs.filesystem;
 
-import com.nytimes.android.external.fs.impl.FileSystemImpl;
 import java.io.File;
 import java.io.IOException;
 

--- a/filesystem/src/main/java/com/nytimes/android/external/fs/filesystem/FileSystemImpl.java
+++ b/filesystem/src/main/java/com/nytimes/android/external/fs/filesystem/FileSystemImpl.java
@@ -1,8 +1,7 @@
-package com.nytimes.android.external.fs.impl;
+package com.nytimes.android.external.fs.filesystem;
 
 import com.nytimes.android.external.cache.CacheLoader;
 import com.nytimes.android.external.cache.LoadingCache;
-import com.nytimes.android.external.fs.FileSystem;
 import com.nytimes.android.external.fs.Util;
 
 import java.io.File;
@@ -22,13 +21,13 @@ import static java.lang.String.format;
  * <p>
  * All operations are on the caller's thread.
  */
-public class FileSystemImpl implements FileSystem {
+class FileSystemImpl implements FileSystem {
 
     private final Util util = new Util();
-    final LoadingCache<String, FSFile> files;
-    final File root;
+    private final LoadingCache<String, FSFile> files;
+    private final File root;
 
-    public FileSystemImpl(final File root) throws IOException {
+    FileSystemImpl(final File root) throws IOException {
         this.root = root;
 
         this.files = newBuilder().maximumSize(20)

--- a/filesystem/src/test/java/com/nytimes/android/external/fs/MultiTest.java
+++ b/filesystem/src/test/java/com/nytimes/android/external/fs/MultiTest.java
@@ -1,24 +1,21 @@
 package com.nytimes.android.external.fs;
 
 import com.google.common.collect.ImmutableMap;
+import com.nytimes.android.external.fs.filesystem.FileSystem;
+import com.nytimes.android.external.fs.filesystem.FileSystemFactory;
 import com.nytimes.android.external.fs.impl.BaseTestCase;
-import com.nytimes.android.external.fs.impl.FileSystemImpl;
-
-import org.junit.Test;
-
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-
 import okio.BufferedSource;
 import okio.Okio;
+import org.junit.Test;
 
 import static com.google.common.base.Charsets.UTF_8;
 import static com.google.common.io.Files.createTempDir;
 import static java.util.Arrays.asList;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class MultiTest extends BaseTestCase {
@@ -31,7 +28,7 @@ public class MultiTest extends BaseTestCase {
 
     private FileSystem createAndPopulateTestFileSystem() throws IOException {
         File baseDir = createTempDir();
-        FileSystem fileSystem = new FileSystemImpl(baseDir);
+        FileSystem fileSystem = FileSystemFactory.create(baseDir);
         for (String path : fileData.keySet()) {
             for (String data : fileData.get(path)) {
                 BufferedSource source = source(data);

--- a/filesystem/src/test/java/com/nytimes/android/external/fs/impl/SimpleTest.java
+++ b/filesystem/src/test/java/com/nytimes/android/external/fs/impl/SimpleTest.java
@@ -1,22 +1,19 @@
 package com.nytimes.android.external.fs.impl;
 
 
-import com.nytimes.android.external.fs.FileSystem;
-
-import org.junit.Before;
-import org.junit.Test;
-
+import com.nytimes.android.external.fs.filesystem.FileSystem;
+import com.nytimes.android.external.fs.filesystem.FileSystemFactory;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-
 import okio.BufferedSource;
 import okio.Okio;
+import org.junit.Before;
+import org.junit.Test;
 
 import static com.google.common.base.Charsets.UTF_8;
 import static com.google.common.io.Files.createTempDir;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class SimpleTest extends BaseTestCase {
@@ -29,7 +26,7 @@ public class SimpleTest extends BaseTestCase {
     @Before
     public void start() throws IOException {
         File baseDir = createTempDir();
-        fileSystem = new FileSystemImpl(baseDir);
+        fileSystem = FileSystemFactory.create(baseDir);
     }
 
     @Test(expected = FileNotFoundException.class)


### PR DESCRIPTION
This PR introduces a factory for FileSystem and hides FileSystemImpl.

You can now request a new instance of FileSystemImpl with `FileSystemFactory.create(root)`