### PR TITLE
Fix memory caching issue with Equivalence.Equals

### DIFF
--- a/store/src/main/java/com/nytimes/android/external/store/base/impl/BarCode.java
+++ b/store/src/main/java/com/nytimes/android/external/store/base/impl/BarCode.java
@@ -37,4 +37,29 @@ public final class BarCode implements Serializable {
     public static BarCode empty() {
         return new BarCode("", "");
     }
+
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (!(object instanceof BarCode)) {
+            return false;
+        }
+        BarCode barCode = (BarCode) object;
+
+        if (!key.equals(barCode.key)) {
+            return false;
+        }
+        if (!type.equals(barCode.type)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public int hashCode() {
+        int result = key.hashCode();
+        result = 31 * result + type.hashCode();
+        return result;
+    }
 }

--- a/store/src/test/java/com/nytimes/android/external/store/StoreTest.java
+++ b/store/src/test/java/com/nytimes/android/external/store/StoreTest.java
@@ -1,5 +1,7 @@
 package com.nytimes.android.external.store;
 
+import com.nytimes.android.external.cache.Cache;
+import com.nytimes.android.external.cache.CacheBuilder;
 import com.nytimes.android.external.store.base.Fetcher;
 import com.nytimes.android.external.store.base.Persister;
 import com.nytimes.android.external.store.base.Store;
@@ -13,6 +15,8 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import java.util.concurrent.TimeUnit;
+
 import rx.Observable;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -25,6 +29,7 @@ public class StoreTest {
 
     private static final String DISK = "disk";
     private static final String NETWORK = "fetch";
+    private static final String MEMORY = "memory";
 
     @Mock
     Fetcher<String> fetcher;
@@ -110,4 +115,19 @@ public class StoreTest {
         assertThat(value).isEqualTo(NETWORK);
     }
 
+
+    @Test
+    public void testEquivalence() {
+        Cache<BarCode, String> cache = CacheBuilder.newBuilder()
+                .maximumSize(1)
+                .expireAfterAccess(Long.MAX_VALUE, TimeUnit.SECONDS)
+                .build();
+
+        cache.put(barCode, MEMORY);
+        String value = cache.getIfPresent(barCode);
+        assertThat(value).isEqualTo(MEMORY);
+
+        value = cache.getIfPresent(new BarCode(barCode.getType(), barCode.getKey()));
+        assertThat(value).isEqualTo(MEMORY);
+    }
 }


### PR DESCRIPTION
Currently, memory cache can not handle multiple `BarCode` instance that have same contents as expected. Bud disk cache can handle that as expected.

This PR implements `BarCode.hashCode` and `BarCode.equals` so that `Equivalence.Equals` works as expected.