### PR TITLE
fix race condition of 2 fetch requests too quickly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ ext {
 
     // POM file
     GROUP = "com.nytimes.android"
-    VERSION_NAME = "1.0.5-SNAPSHOT"
+    VERSION_NAME = "1.0.6-SNAPSHOT"
     POM_PACKAGING = "pom"
     POM_DESCRIPTION = "Store"
 

--- a/buildsystem/dependencies.gradle
+++ b/buildsystem/dependencies.gradle
@@ -26,7 +26,7 @@ ext.versions = [
         butterKnife          : '7.0.1',
 
         // Reactive.
-        rxJava               : '1.1.6',
+        rxJava               : '1.2.4',
         rxJavaProGuardRules  : '1.1.6.0',
         rxJavaAsyncUtil      : '0.21.0',
         rxAndroid            : '1.2.1',

--- a/store/src/main/java/com/nytimes/android/external/store/base/impl/RealInternalStore.java
+++ b/store/src/main/java/com/nytimes/android/external/store/base/impl/RealInternalStore.java
@@ -16,7 +16,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import rx.Observable;
-import rx.functions.Action0;
 import rx.functions.Action1;
 import rx.functions.Func0;
 import rx.functions.Func1;
@@ -199,13 +198,7 @@ final class RealInternalStore<Raw, Parsed> implements InternalStore<Parsed> {
                     public void call(Parsed data) {
                         notifySubscribers(data);
                     }
-                })
-                .doOnTerminate(new Action0() {
-                    @Override
-                    public void call() {
-                        inFlightRequests.invalidate(barCode);
-                    }
-                });
+                }).cache();
     }
 
     void notifySubscribers(Parsed data) {

--- a/store/src/main/java/com/nytimes/android/external/store/base/impl/RealInternalStore.java
+++ b/store/src/main/java/com/nytimes/android/external/store/base/impl/RealInternalStore.java
@@ -16,6 +16,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import rx.Observable;
+import rx.functions.Action0;
 import rx.functions.Action1;
 import rx.functions.Func0;
 import rx.functions.Func1;
@@ -198,7 +199,14 @@ final class RealInternalStore<Raw, Parsed> implements InternalStore<Parsed> {
                     public void call(Parsed data) {
                         notifySubscribers(data);
                     }
-                }).cache();
+                })
+                .doOnTerminate(new Action0() {
+                    @Override
+                    public void call() {
+                        inFlightRequests.invalidate(barCode);
+                    }
+                })
+                .cache();
     }
 
     void notifySubscribers(Parsed data) {

--- a/store/src/main/java/com/nytimes/android/external/store/base/impl/RealInternalStore.java
+++ b/store/src/main/java/com/nytimes/android/external/store/base/impl/RealInternalStore.java
@@ -80,7 +80,8 @@ final class RealInternalStore<Raw, Parsed> implements InternalStore<Parsed> {
      * @param barCode
      * @return an observable from the first data source that is available
      */
-    @NonNull @Override
+    @NonNull
+    @Override
     public Observable<Parsed> get(@NonNull final BarCode barCode) {
         return Observable.concat(
                 cache(barCode),
@@ -140,7 +141,8 @@ final class RealInternalStore<Raw, Parsed> implements InternalStore<Parsed> {
      *
      * @return data from fetch and store it in memory and persister
      */
-    @NonNull @Override
+    @NonNull
+    @Override
     public Observable<Parsed> fetch(@NonNull final BarCode barCode) {
         return Observable.defer(new Func0<Observable<Parsed>>() {
             @Nullable
@@ -219,7 +221,8 @@ final class RealInternalStore<Raw, Parsed> implements InternalStore<Parsed> {
      *
      * @return
      */
-    @NonNull @Override
+    @NonNull
+    @Override
     public Observable<Parsed> stream(@NonNull BarCode id) {
 
         Observable<Parsed> stream = subject.asObservable();
@@ -232,7 +235,8 @@ final class RealInternalStore<Raw, Parsed> implements InternalStore<Parsed> {
         return stream;
     }
 
-    @NonNull @Override
+    @NonNull
+    @Override
     public Observable<Parsed> stream() {
         return subject.asObservable();
     }

--- a/store/src/test/java/com/nytimes/android/external/store/StoreTest.java
+++ b/store/src/test/java/com/nytimes/android/external/store/StoreTest.java
@@ -16,8 +16,11 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
+import rx.Emitter;
 import rx.Observable;
+import rx.functions.Action1;
 import rx.functions.Func2;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -37,6 +40,7 @@ public class StoreTest {
     @Mock
     Persister<String> persister;
     private final BarCode barCode = new BarCode("key", "value");
+    private final AtomicInteger counter = new AtomicInteger(0);
 
     @Before
     public void setUp() {
@@ -79,9 +83,20 @@ public class StoreTest {
                 .fetcher(fetcher)
                 .open();
 
+        Observable<String> networkObservable =
+                Observable.fromEmitter(new Action1<Emitter<String>>() {
+                    @Override
+                    public void call(Emitter<String> emitter) {
+                        if (counter.incrementAndGet() == 1) {
+                            emitter.onNext(NETWORK);
 
+                        } else {
+                            emitter.onError(new RuntimeException("Yo Dawg your inflight is broken"));
+                        }
+                    }
+                }, Emitter.BackpressureMode.NONE);
         when(fetcher.fetch(barCode))
-                .thenReturn(Observable.just(NETWORK));
+                .thenReturn(networkObservable);
 
         when(persister.read(barCode))
                 .thenReturn(Observable.<String>empty())
@@ -90,16 +105,17 @@ public class StoreTest {
         when(persister.write(barCode, NETWORK))
                 .thenReturn(Observable.just(true));
 
-        String value = simpleStore.get(barCode).toBlocking().first();
 
-        assertThat(value).isEqualTo(DISK);
-        value = simpleStore.get(barCode).zipWith(simpleStore.get(barCode), new Func2<String, String, String>() {
-            @Override
-            public String call(String s, String s2) {
-                return "hello";
-            }
-        }).toBlocking().first();
-        assertThat(value).isEqualTo("hello");
+        String response = simpleStore.get(barCode).zipWith(simpleStore.get(barCode),
+                new Func2<String, String, String>() {
+                    @Override
+                    public String call(String s, String s2) {
+                        return "hello";
+                    }
+                })
+                .toBlocking()
+                .first();
+        assertThat(response).isEqualTo("hello");
         verify(fetcher, times(1)).fetch(barCode);
     }
 
@@ -132,6 +148,7 @@ public class StoreTest {
         NoopPersister<String> persister = spy(new NoopPersister<String>());
         Store<String> simpleStore = new RealStore<>(fetcher, persister);
         simpleStore.clearMemory();
+
 
         when(fetcher.fetch(barCode))
                 .thenReturn(Observable.just(NETWORK));


### PR DESCRIPTION
We were inflighting the network observable.  What was happening is that we were retaining the observable in flight and then subscribing to it for each caller. Well each caller would then reexecute the observable.  Adding a `cache` operator fixed the problem :-)