### PR TITLE
Migrate Barcode to any Type

### DIFF
--- a/app/src/main/java/com/nytimes/android/sample/activity/PersistingStoreActivity.java
+++ b/app/src/main/java/com/nytimes/android/sample/activity/PersistingStoreActivity.java
@@ -6,6 +6,7 @@ import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.Toolbar;
 import android.widget.Toast;
+
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.nytimes.android.external.fs.SourcePersisterFactory;
@@ -22,8 +23,10 @@ import com.nytimes.android.sample.data.model.Post;
 import com.nytimes.android.sample.data.model.RedditData;
 import com.nytimes.android.sample.data.remote.Api;
 import com.nytimes.android.sample.reddit.PostAdapter;
+
 import java.io.IOException;
 import java.util.List;
+
 import okio.BufferedSource;
 import retrofit2.GsonConverterFactory;
 import retrofit2.Retrofit;
@@ -37,7 +40,7 @@ import static android.widget.Toast.makeText;
 
 public class PersistingStoreActivity extends AppCompatActivity {
 
-    private Persister<BufferedSource> persister;
+    private Persister<BufferedSource,BarCode> persister;
     private RecyclerView recyclerView;
     private PostAdapter postAdapter;
 
@@ -72,7 +75,8 @@ public class PersistingStoreActivity extends AppCompatActivity {
                 .toList()
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(this::showPosts, throwable -> {});
+                .subscribe(this::showPosts, throwable -> {
+                });
     }
 
     private void showPosts(List<Post> posts) {
@@ -89,14 +93,14 @@ public class PersistingStoreActivity extends AppCompatActivity {
     }
 
     private Store<RedditData> provideRedditStore() {
-        return ParsingStoreBuilder.<BufferedSource,RedditData>builder()
+        return ParsingStoreBuilder.<BufferedSource, RedditData>builder()
                 .fetcher(this::fetcher)
                 .persister(persister)
-                .parser(GsonParserFactory.createSourceParser(provideGson(),RedditData.class))
+                .parser(GsonParserFactory.createSourceParser(provideGson(), RedditData.class))
                 .open();
     }
 
-    private Persister<BufferedSource> newPersister() throws IOException {
+    private Persister<BufferedSource,BarCode> newPersister() throws IOException {
         return SourcePersisterFactory.create(getApplicationContext().getCacheDir());
     }
 

--- a/app/src/test/java/com/nytimes/android/sample/StoreIntegrationTest.java
+++ b/app/src/test/java/com/nytimes/android/sample/StoreIntegrationTest.java
@@ -7,6 +7,8 @@ import com.nytimes.android.external.store.base.impl.StoreBuilder;
 import org.junit.Before;
 import org.junit.Test;
 
+import rx.Observable;
+
 import static junit.framework.Assert.assertEquals;
 
 /**
@@ -27,7 +29,7 @@ public class StoreIntegrationTest {
     @Before
     public void setUp() throws Exception {
         testStore = StoreBuilder.<String>builder()
-                .nonObservableFetcher(barCode -> "hello")
+                .fetcher(barCode -> Observable.just("hello"))
                 .open();
 
     }
@@ -35,7 +37,7 @@ public class StoreIntegrationTest {
     @Test
     public void testRepeatedGet() throws Exception {
         String first = testStore.get(BarCode.empty()).toBlocking().first();
-        assertEquals(first,"hello");
+        assertEquals(first, "hello");
 
     }
 }

--- a/filesystem/src/main/java/com/nytimes/android/external/fs/SourceFileReader.java
+++ b/filesystem/src/main/java/com/nytimes/android/external/fs/SourceFileReader.java
@@ -15,7 +15,7 @@ import rx.Observable;
 
 import static com.nytimes.android.external.fs.SourcePersister.pathForBarcode;
 
-public class SourceFileReader implements DiskRead<BufferedSource> {
+public class SourceFileReader implements DiskRead<BufferedSource, BarCode> {
 
     final FileSystem fileSystem;
 

--- a/filesystem/src/main/java/com/nytimes/android/external/fs/SourceFileWriter.java
+++ b/filesystem/src/main/java/com/nytimes/android/external/fs/SourceFileWriter.java
@@ -15,7 +15,7 @@ import rx.Observable;
 import static com.nytimes.android.external.fs.SourcePersister.pathForBarcode;
 import static okio.Okio.buffer;
 
-public class SourceFileWriter implements DiskWrite<BufferedSource> {
+public class SourceFileWriter implements DiskWrite<BufferedSource, BarCode> {
 
     final FileSystem fileSystem;
 

--- a/filesystem/src/main/java/com/nytimes/android/external/fs/SourcePersister.java
+++ b/filesystem/src/main/java/com/nytimes/android/external/fs/SourcePersister.java
@@ -5,8 +5,9 @@ import com.nytimes.android.external.fs.filesystem.FileSystem;
 import com.nytimes.android.external.store.base.Persister;
 import com.nytimes.android.external.store.base.impl.BarCode;
 
-import javax.annotation.Nonnull;
+
 import javax.inject.Inject;
+import javax.annotation.Nonnull;
 
 import okio.BufferedSource;
 import rx.Observable;
@@ -20,7 +21,7 @@ import rx.Observable;
  * .parser(new GsonSourceParser<>(gson, BookResults.class))
  * .open();
  */
-public class SourcePersister implements Persister<BufferedSource> {
+public class SourcePersister implements Persister<BufferedSource, BarCode> {
 
     @Nonnull
     private final SourceFileReader sourceFileReader;
@@ -34,6 +35,11 @@ public class SourcePersister implements Persister<BufferedSource> {
     }
 
     @Nonnull
+    static String pathForBarcode(@Nonnull BarCode barCode) {
+        return barCode.getType() + barCode.getKey();
+    }
+
+    @Nonnull
     @Override
     public Observable<BufferedSource> read(@Nonnull final BarCode barCode) {
         return sourceFileReader.exists(barCode) ? sourceFileReader.read(barCode) : Observable.<BufferedSource>empty();
@@ -43,12 +49,6 @@ public class SourcePersister implements Persister<BufferedSource> {
     @Override
     public Observable<Boolean> write(@Nonnull final BarCode barCode, @Nonnull final BufferedSource data) {
         return sourceFileWriter.write(barCode, data);
-    }
-
-
-    @Nonnull
-    static String pathForBarcode(@Nonnull BarCode barCode) {
-        return barCode.getType() + barCode.getKey();
     }
 
 }

--- a/filesystem/src/main/java/com/nytimes/android/external/fs/SourcePersisterFactory.java
+++ b/filesystem/src/main/java/com/nytimes/android/external/fs/SourcePersisterFactory.java
@@ -1,13 +1,14 @@
 package com.nytimes.android.external.fs;
 
+import javax.annotation.Nonnull;
+
 import com.nytimes.android.external.fs.filesystem.FileSystem;
 import com.nytimes.android.external.fs.filesystem.FileSystemFactory;
 import com.nytimes.android.external.store.base.Persister;
+import com.nytimes.android.external.store.base.impl.BarCode;
 
 import java.io.File;
 import java.io.IOException;
-
-import javax.annotation.Nonnull;
 
 import okio.BufferedSource;
 
@@ -26,7 +27,7 @@ public final class SourcePersisterFactory {
      * @throws IOException
      */
     @Nonnull
-    public static Persister<BufferedSource> create(@Nonnull File root) throws IOException {
+    public static Persister<BufferedSource, BarCode> create(@Nonnull File root) throws IOException {
         if (root == null) {
             throw new IllegalArgumentException("root file cannot be null.");
         }
@@ -40,7 +41,7 @@ public final class SourcePersisterFactory {
      * @throws IOException
      */
     @Nonnull
-    public static Persister<BufferedSource> create(@Nonnull FileSystem fileSystem) throws IOException {
+    public static Persister<BufferedSource, BarCode> create(@Nonnull FileSystem fileSystem) throws IOException {
         if (fileSystem == null) {
             throw new IllegalArgumentException("fileSystem cannot be null.");
         }

--- a/filesystem/src/main/java/com/nytimes/android/external/fs/filesystem/FileSystem.java
+++ b/filesystem/src/main/java/com/nytimes/android/external/fs/filesystem/FileSystem.java
@@ -56,7 +56,7 @@ public interface FileSystem {
      * write a new version of a file. No readers will "see" this version until it has successfully been completely
      * written to and closed. In case of error, the version is deleted from disk.
      *
-     * @param path what to write to
+     * @param path   what to write to
      * @param source a {@link BufferedSource} containing the content to be written to disk. Caller must close it!
      * @throws IOException
      */

--- a/filesystem/src/main/java/com/nytimes/android/external/fs/filesystem/FileSystemFactory.java
+++ b/filesystem/src/main/java/com/nytimes/android/external/fs/filesystem/FileSystemFactory.java
@@ -1,26 +1,26 @@
 package com.nytimes.android.external.fs.filesystem;
 
+import javax.annotation.Nonnull;
+
 import java.io.File;
 import java.io.IOException;
-
-import javax.annotation.Nonnull;
 
 /**
  * Factory for {@link FileSystem}.
  */
 public final class FileSystemFactory {
-  private FileSystemFactory() {
-  }
+    private FileSystemFactory() {
+    }
 
-  /**
-   * Creates new instance of {@link FileSystemImpl}.
-   *
-   * @param root root directory.
-   * @return new instance of {@link FileSystemImpl}.
-   * @throws IOException
-   */
-  @Nonnull
-  public static FileSystem create(@Nonnull File root) throws IOException {
-    return new FileSystemImpl(root);
-  }
+    /**
+     * Creates new instance of {@link FileSystemImpl}.
+     *
+     * @param root root directory.
+     * @return new instance of {@link FileSystemImpl}.
+     * @throws IOException
+     */
+    @Nonnull
+    public static FileSystem create(@Nonnull File root) throws IOException {
+        return new FileSystemImpl(root);
+    }
 }

--- a/filesystem/src/test/java/com/nytimes/android/external/fs/MultiTest.java
+++ b/filesystem/src/test/java/com/nytimes/android/external/fs/MultiTest.java
@@ -28,6 +28,10 @@ public class MultiTest {
             .put("/foo/bar/baz.xyz", asList("sasffvSFv", "AsfgsdvzsfbvasFgae", "szfvzsfszfvzsvbzdsfb"))
             .build();
 
+    private static BufferedSource source(String data) {
+        return Okio.buffer(Okio.source(new ByteArrayInputStream(data.getBytes(UTF_8))));
+    }
+
     private FileSystem createAndPopulateTestFileSystem() throws IOException {
         File baseDir = createTempDir();
         FileSystem fileSystem = FileSystemFactory.create(baseDir);
@@ -61,9 +65,5 @@ public class MultiTest {
             assertCount++;
         }
         assertThat(assertCount).isEqualTo(fileData.size());
-    }
-
-    private static BufferedSource source(String data) {
-        return Okio.buffer(Okio.source(new ByteArrayInputStream(data.getBytes(UTF_8))));
     }
 }

--- a/filesystem/src/test/java/com/nytimes/android/external/fs/SourceDiskDaoStoreTest.java
+++ b/filesystem/src/test/java/com/nytimes/android/external/fs/SourceDiskDaoStoreTest.java
@@ -27,11 +27,15 @@ import static org.mockito.Mockito.when;
 public class SourceDiskDaoStoreTest {
     public static final String KEY = "key";
     @Mock
-    Fetcher<BufferedSource> fetcher;
+    Fetcher<BufferedSource, BarCode> fetcher;
     @Mock
     SourcePersister diskDAO;
-
     private final BarCode barCode = new BarCode("value", KEY);
+
+
+    private static BufferedSource source(String data) {
+        return Okio.buffer(Okio.source(new ByteArrayInputStream(data.getBytes(UTF_8))));
+    }
 
     @Test
     public void testSimple() {
@@ -66,10 +70,6 @@ public class SourceDiskDaoStoreTest {
         result = simpleStore.get(barCode).toBlocking().first();
         assertThat(result.bar).isEqualTo(KEY);
         verify(fetcher, times(1)).fetch(barCode);
-    }
-
-    private static BufferedSource source(String data) {
-        return Okio.buffer(Okio.source(new ByteArrayInputStream(data.getBytes(UTF_8))));
     }
 
     private static class Foo {

--- a/filesystem/src/test/java/com/nytimes/android/external/fs/SourceFilerReaderWriterStoreTest.java
+++ b/filesystem/src/test/java/com/nytimes/android/external/fs/SourceFilerReaderWriterStoreTest.java
@@ -26,13 +26,17 @@ import static org.mockito.Mockito.when;
 public class SourceFilerReaderWriterStoreTest {
     public static final String KEY = "key";
     @Mock
-    Fetcher<BufferedSource> fetcher;
+    Fetcher<BufferedSource, BarCode> fetcher;
     @Mock
     SourceFileReader fileReader;
     @Mock
     SourceFileWriter fileWriter;
-
     private final BarCode barCode = new BarCode("value", KEY);
+
+
+    private static BufferedSource source(String data) {
+        return Okio.buffer(Okio.source(new ByteArrayInputStream(data.getBytes(UTF_8))));
+    }
 
     @Test
     public void testSimple() {
@@ -66,10 +70,6 @@ public class SourceFilerReaderWriterStoreTest {
         result = simpleStore.get(barCode).toBlocking().first();
         assertThat(result.bar).isEqualTo(KEY);
         verify(fetcher, times(1)).fetch(barCode);
-    }
-
-    private static BufferedSource source(String data) {
-        return Okio.buffer(Okio.source(new ByteArrayInputStream(data.getBytes(UTF_8))));
     }
 
     private static class Foo {

--- a/middleware-jackson/src/test/java/com/nytimes/android/external/store/middleware/jackson/JacksonReaderParserStoreTest.java
+++ b/middleware-jackson/src/test/java/com/nytimes/android/external/store/middleware/jackson/JacksonReaderParserStoreTest.java
@@ -33,15 +33,12 @@ public class JacksonReaderParserStoreTest {
     private static final String KEY = "key";
     private static final String sourceString =
             "{\"number\":123,\"string\":\"abc\",\"bars\":[{\"string\":\"def\"},{\"string\":\"ghi\"}]}";
-
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
-
     @Mock
-    Fetcher<Reader> fetcher;
+    Fetcher<Reader, BarCode> fetcher;
     @Mock
-    Persister<Reader> persister;
-
+    Persister<Reader, BarCode> persister;
     private final BarCode barCode = new BarCode("value", KEY);
 
     @Before

--- a/middleware-jackson/src/test/java/com/nytimes/android/external/store/middleware/jackson/JacksonSourceParserStoreTest.java
+++ b/middleware-jackson/src/test/java/com/nytimes/android/external/store/middleware/jackson/JacksonSourceParserStoreTest.java
@@ -35,16 +35,17 @@ public class JacksonSourceParserStoreTest {
     private static final String KEY = "key";
     private static final String sourceString =
             "{\"number\":123,\"string\":\"abc\",\"bars\":[{\"string\":\"def\"},{\"string\":\"ghi\"}]}";
-
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
-
     @Mock
-    Fetcher<BufferedSource> fetcher;
+    Fetcher<BufferedSource, BarCode> fetcher;
     @Mock
-    Persister<BufferedSource> persister;
-
+    Persister<BufferedSource, BarCode> persister;
     private final BarCode barCode = new BarCode("value", KEY);
+
+    private static BufferedSource source(String data) {
+        return Okio.buffer(Okio.source(new ByteArrayInputStream(data.getBytes(Charset.defaultCharset()))));
+    }
 
     @Before
     public void setUp() throws Exception {
@@ -130,10 +131,6 @@ public class JacksonSourceParserStoreTest {
     public void testNullType() {
         expectedException.expect(NullPointerException.class);
         JacksonParserFactory.createStringParser(null);
-    }
-
-    private static BufferedSource source(String data) {
-        return Okio.buffer(Okio.source(new ByteArrayInputStream(data.getBytes(Charset.defaultCharset()))));
     }
 
 }

--- a/middleware-jackson/src/test/java/com/nytimes/android/external/store/middleware/jackson/JacksonStringParserStoreTest.java
+++ b/middleware-jackson/src/test/java/com/nytimes/android/external/store/middleware/jackson/JacksonStringParserStoreTest.java
@@ -30,15 +30,12 @@ public class JacksonStringParserStoreTest {
     private static final String KEY = "key";
     private static final String source =
             "{\"number\":123,\"string\":\"abc\",\"bars\":[{\"string\":\"def\"},{\"string\":\"ghi\"}]}";
-
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
-
     @Mock
-    Fetcher<String> fetcher;
+    Fetcher<String, BarCode> fetcher;
     @Mock
-    Persister<String> persister;
-
+    Persister<String, BarCode> persister;
     private final BarCode barCode = new BarCode("value", KEY);
 
     @Before

--- a/middleware-moshi/src/test/java/com/nytimes/android/external/store/middleware/moshi/MoshiSourceParserTest.java
+++ b/middleware-moshi/src/test/java/com/nytimes/android/external/store/middleware/moshi/MoshiSourceParserTest.java
@@ -3,7 +3,7 @@ package com.nytimes.android.external.store.middleware.moshi;
 import com.nytimes.android.external.store.base.Fetcher;
 import com.nytimes.android.external.store.base.Parser;
 import com.nytimes.android.external.store.base.Persister;
-import com.nytimes.android.external.store.base.Store;
+import com.nytimes.android.external.store.base.beta.Store;
 import com.nytimes.android.external.store.base.impl.BarCode;
 import com.nytimes.android.external.store.base.impl.ParsingStoreBuilder;
 import com.nytimes.android.external.store.middleware.moshi.data.Foo;
@@ -33,16 +33,17 @@ public class MoshiSourceParserTest {
     private static final String KEY = "key";
     private static final String sourceString =
             "{\"number\":123,\"string\":\"abc\",\"bars\":[{\"string\":\"def\"},{\"string\":\"ghi\"}]}";
-
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
-
     @Mock
-    Fetcher<BufferedSource> fetcher;
+    Fetcher<BufferedSource, BarCode> fetcher;
     @Mock
-    Persister<BufferedSource> persister;
-
+    Persister<BufferedSource, BarCode> persister;
     private final BarCode barCode = new BarCode("value", KEY);
+
+    private static BufferedSource source(String data) {
+        return Okio.buffer(Okio.source(new ByteArrayInputStream(data.getBytes(Charset.defaultCharset()))));
+    }
 
     @Before
     public void setUp() throws Exception {
@@ -67,7 +68,7 @@ public class MoshiSourceParserTest {
 
         Parser<BufferedSource, Foo> parser = MoshiParserFactory.createSourceParser(Foo.class);
 
-        Store<Foo> store = ParsingStoreBuilder.<BufferedSource, Foo>builder()
+        Store<Foo, BarCode> store = ParsingStoreBuilder.<BufferedSource, Foo>builder()
                 .persister(persister)
                 .fetcher(fetcher)
                 .parser(parser)
@@ -95,10 +96,6 @@ public class MoshiSourceParserTest {
     public void testNullType() {
         expectedException.expect(NullPointerException.class);
         MoshiParserFactory.createSourceParser(null, Foo.class);
-    }
-
-    private static BufferedSource source(String data) {
-        return Okio.buffer(Okio.source(new ByteArrayInputStream(data.getBytes(Charset.defaultCharset()))));
     }
 
 }

--- a/middleware-moshi/src/test/java/com/nytimes/android/external/store/middleware/moshi/MoshiStringParserStoreTest.java
+++ b/middleware-moshi/src/test/java/com/nytimes/android/external/store/middleware/moshi/MoshiStringParserStoreTest.java
@@ -2,7 +2,7 @@ package com.nytimes.android.external.store.middleware.moshi;
 
 import com.nytimes.android.external.store.base.Fetcher;
 import com.nytimes.android.external.store.base.Persister;
-import com.nytimes.android.external.store.base.Store;
+import com.nytimes.android.external.store.base.beta.Store;
 import com.nytimes.android.external.store.base.impl.BarCode;
 import com.nytimes.android.external.store.base.impl.ParsingStoreBuilder;
 import com.nytimes.android.external.store.middleware.moshi.data.Foo;
@@ -27,15 +27,12 @@ public class MoshiStringParserStoreTest {
     private static final String KEY = "key";
     private static final String source =
             "{\"number\":123,\"string\":\"abc\",\"bars\":[{\"string\":\"def\"},{\"string\":\"ghi\"}]}";
-
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
-
     @Mock
-    Fetcher<String> fetcher;
+    Fetcher<String, BarCode> fetcher;
     @Mock
-    Persister<String> persister;
-
+    Persister<String, BarCode> persister;
     private final BarCode barCode = new BarCode("value", KEY);
 
     @Before
@@ -55,7 +52,7 @@ public class MoshiStringParserStoreTest {
 
     @Test
     public void testMoshiString() {
-        Store<Foo> store = ParsingStoreBuilder.<String, Foo>builder()
+        Store<Foo, BarCode> store = ParsingStoreBuilder.<String, Foo>builder()
                 .persister(persister)
                 .fetcher(fetcher)
                 .parser(MoshiParserFactory.createStringParser(Foo.class))

--- a/middleware/src/test/java/com/nytimes/android/external/store/GenericParserStoreTest.java
+++ b/middleware/src/test/java/com/nytimes/android/external/store/GenericParserStoreTest.java
@@ -28,11 +28,15 @@ import static org.mockito.Mockito.when;
 public class GenericParserStoreTest {
     public static final String KEY = "key";
     @Mock
-    Fetcher<BufferedSource> fetcher;
+    Fetcher<BufferedSource, BarCode> fetcher;
     @Mock
-    Persister<BufferedSource> persister;
-
+    Persister<BufferedSource, BarCode> persister;
     private final BarCode barCode = new BarCode("value", KEY);
+
+
+    private static BufferedSource source(String data) {
+        return Okio.buffer(Okio.source(new ByteArrayInputStream(data.getBytes(UTF_8))));
+    }
 
     @Test
     public void testSimple() {
@@ -69,10 +73,6 @@ public class GenericParserStoreTest {
         result = simpleStore.get(barCode).toBlocking().first();
         assertThat(result.bar).isEqualTo(KEY);
         verify(fetcher, times(1)).fetch(barCode);
-    }
-
-    private static BufferedSource source(String data) {
-        return Okio.buffer(Okio.source(new ByteArrayInputStream(data.getBytes(UTF_8))));
     }
 
     private static class Foo {

--- a/middleware/src/test/java/com/nytimes/android/external/store/GsonSourceListParserTest.java
+++ b/middleware/src/test/java/com/nytimes/android/external/store/GsonSourceListParserTest.java
@@ -31,11 +31,14 @@ import static org.mockito.Mockito.when;
 public class GsonSourceListParserTest {
     public static final String KEY = "key";
     @Mock
-    Fetcher<BufferedSource> fetcher;
+    Fetcher<BufferedSource, BarCode> fetcher;
     @Mock
-    Persister<BufferedSource> persister;
-
+    Persister<BufferedSource, BarCode> persister;
     private final BarCode barCode = new BarCode("value", KEY);
+
+    private static BufferedSource source(String data) {
+        return Okio.buffer(Okio.source(new ByteArrayInputStream(data.getBytes(UTF_8))));
+    }
 
     @Test
     public void testSimple() {
@@ -77,10 +80,6 @@ public class GsonSourceListParserTest {
         assertThat(result.get(2).value).isEqualTo("c");
 
         verify(fetcher, times(1)).fetch(barCode);
-    }
-
-    private static BufferedSource source(String data) {
-        return Okio.buffer(Okio.source(new ByteArrayInputStream(data.getBytes(UTF_8))));
     }
 
     private static class Foo {

--- a/pmd-ruleset.xml
+++ b/pmd-ruleset.xml
@@ -95,8 +95,6 @@
     <rule ref="rulesets/java/naming.xml/SuspiciousHashcodeMethodName" />
     <rule ref="rulesets/java/naming.xml/SuspiciousConstantFieldName" />
     <rule ref="rulesets/java/naming.xml/SuspiciousEqualsMethodName" />
-    <rule ref="rulesets/java/naming.xml/AvoidFieldNameMatchingTypeName" />
-    <rule ref="rulesets/java/naming.xml/AvoidFieldNameMatchingMethodName" />
     <rule ref="rulesets/java/naming.xml/NoPackage" />
     <rule ref="rulesets/java/naming.xml/PackageCase" />
     <!--<rule ref="rulesets/java/naming.xml/GenericsNaming" />-->

--- a/store/src/main/java/com/nytimes/android/external/store/base/DiskRead.java
+++ b/store/src/main/java/com/nytimes/android/external/store/base/DiskRead.java
@@ -1,12 +1,10 @@
 package com.nytimes.android.external.store.base;
 
-import com.nytimes.android.external.store.base.impl.BarCode;
-
 import javax.annotation.Nonnull;
 
 import rx.Observable;
 
-public interface DiskRead<Raw> {
+public interface DiskRead<Raw, Key> {
     @Nonnull
-    Observable<Raw> read(BarCode barCode);
+    Observable<Raw> read(Key barCode);
 }

--- a/store/src/main/java/com/nytimes/android/external/store/base/DiskWrite.java
+++ b/store/src/main/java/com/nytimes/android/external/store/base/DiskWrite.java
@@ -1,18 +1,15 @@
 package com.nytimes.android.external.store.base;
 
-
-import com.nytimes.android.external.store.base.impl.BarCode;
-
 import javax.annotation.Nonnull;
 
 import rx.Observable;
 
-public interface DiskWrite<Raw> {
+public interface DiskWrite<Raw, Key> {
     /**
      * @param barCode to use to get data from persister
      *                If data is not available implementer needs to
      *                either return Observable.empty or throw an exception
      */
     @Nonnull
-    Observable<Boolean> write(BarCode barCode, Raw raw);
+    Observable<Boolean> write(Key barCode, Raw raw);
 }

--- a/store/src/main/java/com/nytimes/android/external/store/base/Fetcher.java
+++ b/store/src/main/java/com/nytimes/android/external/store/base/Fetcher.java
@@ -1,8 +1,5 @@
 package com.nytimes.android.external.store.base;
 
-
-import com.nytimes.android.external.store.base.impl.BarCode;
-
 import javax.annotation.Nonnull;
 
 import rx.Observable;
@@ -12,12 +9,12 @@ import rx.Observable;
  *
  * @param <Raw> data type before parsing
  */
-public interface Fetcher<Raw> {
+public interface Fetcher<Raw, Key> {
 
     /**
      * @param barCode Container with Key and Type used as a request param
      * @return Observable that emits {@link Raw} data
      */
     @Nonnull
-    Observable<Raw> fetch(BarCode barCode);
+    Observable<Raw> fetch(Key barCode);
 }

--- a/store/src/main/java/com/nytimes/android/external/store/base/InternalStore.java
+++ b/store/src/main/java/com/nytimes/android/external/store/base/InternalStore.java
@@ -1,7 +1,6 @@
 package com.nytimes.android.external.store.base;
 
-
-import com.nytimes.android.external.store.base.impl.BarCode;
+import com.nytimes.android.external.store.base.beta.Store;
 
 import javax.annotation.Nonnull;
 
@@ -11,9 +10,10 @@ import rx.Observable;
  * this interface allows us to mark a {@link Store} as "internal", exposing methods for retrieving data
  * directly from memory or from disk.
  */
-public interface InternalStore<Parsed> extends Store<Parsed> {
+public interface InternalStore<Parsed, Key> extends Store<Parsed, Key> {
     @Nonnull
-    Observable<Parsed> memory(@Nonnull final BarCode barCode);
+    Observable<Parsed> memory(@Nonnull final Key barCode);
+
     @Nonnull
-    Observable<Parsed> disk(@Nonnull final BarCode barCode);
+    Observable<Parsed> disk(@Nonnull final Key barCode);
 }

--- a/store/src/main/java/com/nytimes/android/external/store/base/Persister.java
+++ b/store/src/main/java/com/nytimes/android/external/store/base/Persister.java
@@ -1,8 +1,5 @@
 package com.nytimes.android.external.store.base;
 
-
-import com.nytimes.android.external.store.base.impl.BarCode;
-
 import javax.annotation.Nonnull;
 
 import rx.Observable;
@@ -12,7 +9,7 @@ import rx.Observable;
  *
  * @param <Raw> data type before parsing
  */
-public interface Persister<Raw> {
+public interface Persister<Raw, Key> {
 
     /**
      * @param barCode to use to get data from persister
@@ -20,12 +17,12 @@ public interface Persister<Raw> {
      *                either return Observable.empty or throw an exception
      */
     @Nonnull
-    Observable<Raw> read(final BarCode barCode);
+    Observable<Raw> read(final Key barCode);
 
     /**
      * @param barCode to use to store data to persister
      * @param raw     raw string to be stored
      */
     @Nonnull
-    Observable<Boolean> write(final BarCode barCode, final Raw raw);
+    Observable<Boolean> write(final Key barCode, final Raw raw);
 }

--- a/store/src/main/java/com/nytimes/android/external/store/base/beta/Store.java
+++ b/store/src/main/java/com/nytimes/android/external/store/base/beta/Store.java
@@ -1,9 +1,9 @@
-package com.nytimes.android.external.store.base;
+package com.nytimes.android.external.store.base.beta;
 
 
 import com.nytimes.android.external.store.base.impl.BarCode;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 import rx.Observable;
 
@@ -16,30 +16,26 @@ import rx.Observable;
  * force a call to {@link Store#fetch(BarCode) Store.fetch() }
  * (skipping cache)
  */
-@Deprecated
-public interface Store<T> extends com.nytimes.android.external.store.base.beta.Store<T, BarCode> {
+public interface Store<T, V> {
 
     /**
      * Return an Observable of T for request Barcode
      * Data will be returned from oldest non expired source
      * Sources are Memory Cache, Disk Cache, Inflight, Network Response
      */
-    @Nonnull
-    @Override
-    Observable<T> get(@Nonnull BarCode barCode);
+    @NotNull
+    Observable<T> get(@NotNull V key);
 
     /**
      * Return an Observable of T for requested Barcode skipping Memory & Disk Cache
      */
-    @Nonnull
-    @Override
-    Observable<T> fetch(@Nonnull BarCode barCode);
+    @NotNull
+    Observable<T> fetch(@NotNull V key);
 
     /**
      * @return an Observable that emits new items when they arrive.
      */
-    @Nonnull
-    @Override
+    @NotNull
     Observable<T> stream();
 
     /**
@@ -51,20 +47,18 @@ public interface Store<T> extends com.nytimes.android.external.store.base.beta.S
      * use {@code store.stream().startWith(store.get(keyAndRawType))}
      */
     @Deprecated
-    @Nonnull
-    Observable<T> stream(BarCode id);
+    @NotNull
+    Observable<T> stream(V id);
 
     /**
      * Clear the memory cache of all entries
      */
-    @Override
     void clearMemory();
 
     /**
      * Purge a particular entry from memory cache.
      */
-    @Override
-    void clearMemory(@Nonnull BarCode barCode);
+    void clearMemory(@NotNull V key);
 
 
 }

--- a/store/src/main/java/com/nytimes/android/external/store/base/beta/Store.java
+++ b/store/src/main/java/com/nytimes/android/external/store/base/beta/Store.java
@@ -3,9 +3,10 @@ package com.nytimes.android.external.store.base.beta;
 
 import com.nytimes.android.external.store.base.impl.BarCode;
 
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 import rx.Observable;
+import rx.annotations.Experimental;
 
 /**
  * a {@link com.nytimes.android.external.store.base.impl.StoreBuilder StoreBuilder}
@@ -23,19 +24,28 @@ public interface Store<T, V> {
      * Data will be returned from oldest non expired source
      * Sources are Memory Cache, Disk Cache, Inflight, Network Response
      */
-    @NotNull
-    Observable<T> get(@NotNull V key);
+    @Nonnull
+    Observable<T> get(@Nonnull V key);
+
+    /**
+     * Calls store.get(), additionally will repeat anytime store.clear(barcode) is called
+     * WARNING: getRefreshing(barcode) is an endless observable, be careful when combining
+     * with operators that expect an OnComplete event
+     */
+    @Experimental
+    Observable<T> getRefreshing(@Nonnull final V key);
+
 
     /**
      * Return an Observable of T for requested Barcode skipping Memory & Disk Cache
      */
-    @NotNull
-    Observable<T> fetch(@NotNull V key);
+    @Nonnull
+    Observable<T> fetch(@Nonnull V key);
 
     /**
      * @return an Observable that emits new items when they arrive.
      */
-    @NotNull
+    @Nonnull
     Observable<T> stream();
 
     /**
@@ -47,7 +57,7 @@ public interface Store<T, V> {
      * use {@code store.stream().startWith(store.get(keyAndRawType))}
      */
     @Deprecated
-    @NotNull
+    @Nonnull
     Observable<T> stream(V id);
 
     /**
@@ -58,7 +68,7 @@ public interface Store<T, V> {
     /**
      * Purge a particular entry from memory cache.
      */
-    void clearMemory(@NotNull V key);
+    void clearMemory(@Nonnull V key);
 
 
 }

--- a/store/src/main/java/com/nytimes/android/external/store/base/impl/BarCode.java
+++ b/store/src/main/java/com/nytimes/android/external/store/base/impl/BarCode.java
@@ -15,27 +15,27 @@ import javax.annotation.Nonnull;
  **/
 @Deprecated
 public final class BarCode implements Serializable {
-    @NotNull
+    @Nonnull
     private final String key;
-    @NotNull
+    @Nonnull
     private final String type;
 
-    public BarCode(@NotNull String type, @NotNull String key) {
+    public BarCode(@Nonnull String type, @Nonnull String key) {
         this.key = key;
         this.type = type;
     }
 
-    @NotNull
+    @Nonnull
     public static BarCode empty() {
         return new BarCode("", "");
     }
 
-    @NotNull
+    @Nonnull
     public String getKey() {
         return key;
     }
 
-    @NotNull
+    @Nonnull
     public String getType() {
         return type;
     }

--- a/store/src/main/java/com/nytimes/android/external/store/base/impl/BarCode.java
+++ b/store/src/main/java/com/nytimes/android/external/store/base/impl/BarCode.java
@@ -1,41 +1,43 @@
 package com.nytimes.android.external.store.base.impl;
 
-import java.io.Serializable;
+import com.nytimes.android.external.store.base.beta.Store;
 
+
+import java.io.Serializable;
 import javax.annotation.Nonnull;
 
 /**
  * {@link com.nytimes.android.external.store.base.impl.BarCode Barcode} is used as a unique
- * identifier for a particular {@link com.nytimes.android.external.store.base.Store  Store}
+ * identifier for a particular {@link Store  Store}
  * <p/>
- * Barcode will be passed to {@link com.nytimes.android.external.store.base.Fetcher  Fetcher}
+ * Barcode will be passed to   Fetcher
  * and {@link com.nytimes.android.external.store.base.Persister  Persister}
  **/
-
+@Deprecated
 public final class BarCode implements Serializable {
-    @Nonnull
+    @NotNull
     private final String key;
-    @Nonnull
+    @NotNull
     private final String type;
 
-    public BarCode(@Nonnull String type, @Nonnull String key) {
+    public BarCode(@NotNull String type, @NotNull String key) {
         this.key = key;
         this.type = type;
     }
 
-    @Nonnull
+    @NotNull
+    public static BarCode empty() {
+        return new BarCode("", "");
+    }
+
+    @NotNull
     public String getKey() {
         return key;
     }
 
-    @Nonnull
+    @NotNull
     public String getType() {
         return type;
-    }
-
-    @Nonnull
-    public static BarCode empty() {
-        return new BarCode("", "");
     }
 
     @Override
@@ -43,17 +45,14 @@ public final class BarCode implements Serializable {
         if (this == object) {
             return true;
         }
-
         if (!(object instanceof BarCode)) {
             return false;
         }
-
         BarCode barCode = (BarCode) object;
 
         if (!key.equals(barCode.key)) {
             return false;
         }
-
         if (!type.equals(barCode.type)) {
             return false;
         }

--- a/store/src/main/java/com/nytimes/android/external/store/base/impl/MultiParser.java
+++ b/store/src/main/java/com/nytimes/android/external/store/base/impl/MultiParser.java
@@ -38,6 +38,6 @@ public class MultiParser<Raw, Parsed> implements Parser<Raw, Parsed> {
 
     private ParserException createParserException() {
         return new ParserException("One of the provided parsers has a wrong typing. " +
-                "Make sure that parsers are passed in a correct order and the types match each other.");
+                "Make sure that parsers are passed in a correct order and the fromTypes match each other.");
     }
 }

--- a/store/src/main/java/com/nytimes/android/external/store/base/impl/ParsingStoreBuilder.java
+++ b/store/src/main/java/com/nytimes/android/external/store/base/impl/ParsingStoreBuilder.java
@@ -9,11 +9,11 @@ import com.nytimes.android.external.store.base.Persister;
 import com.nytimes.android.external.store.base.Store;
 import com.nytimes.android.external.store.util.NoopPersister;
 
-import org.jetbrains.annotations.Nonnull;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
+
+import javax.annotation.Nonnull;
 
 import rx.Observable;
 import rx.functions.Func1;
@@ -84,13 +84,6 @@ public class ParsingStoreBuilder<Raw, Parsed> {
                 return diskWrite.write(barCode, raw);
             }
         };
-        return this;
-    }
-
-    @Nonnull
-    public ParsingStoreBuilder<Raw, Parsed> parser(final @Nonnull Func1<Raw, Parsed> parser) {
-        this.parsers.clear();
-        this.parsers.add((Parser<Raw, Parsed>) parser);
         return this;
     }
 

--- a/store/src/main/java/com/nytimes/android/external/store/base/impl/ParsingStoreBuilder.java
+++ b/store/src/main/java/com/nytimes/android/external/store/base/impl/ParsingStoreBuilder.java
@@ -95,7 +95,7 @@ public class ParsingStoreBuilder<Raw, Parsed> {
     }
 
     @Nonnull
-    public ParsingStoreBuilder<Raw, Parsed> parsers(final @Nonnull List<Parser<Raw, Parsed>> parsers) {
+    public ParsingStoreBuilder<Raw, Parsed> parsers(final @Nonnull List<Parser> parsers) {
         this.parsers.clear();
         this.parsers.addAll(parsers);
         return this;

--- a/store/src/main/java/com/nytimes/android/external/store/base/impl/ParsingStoreBuilder.java
+++ b/store/src/main/java/com/nytimes/android/external/store/base/impl/ParsingStoreBuilder.java
@@ -1,6 +1,5 @@
 package com.nytimes.android.external.store.base.impl;
 
-
 import com.nytimes.android.external.cache.Cache;
 import com.nytimes.android.external.store.base.DiskRead;
 import com.nytimes.android.external.store.base.DiskWrite;
@@ -10,11 +9,11 @@ import com.nytimes.android.external.store.base.Persister;
 import com.nytimes.android.external.store.base.Store;
 import com.nytimes.android.external.store.util.NoopPersister;
 
+import org.jetbrains.annotations.Nonnull;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
-
-import javax.annotation.Nonnull;
 
 import rx.Observable;
 import rx.functions.Func1;
@@ -22,12 +21,12 @@ import rx.functions.Func1;
 /**
  * Builder where there parser is used.
  */
-@SuppressWarnings({"PMD.AvoidFieldNameMatchingMethodName"})
+@Deprecated
 public class ParsingStoreBuilder<Raw, Parsed> {
 
     private final List<Parser> parsers = new ArrayList<>();
-    private Fetcher<Raw> fetcher;
-    private Persister<Raw> persister;
+    private Fetcher<Raw, BarCode> fetcher;
+    private Persister<Raw, BarCode> persister;
     private Cache<BarCode, Observable<Parsed>> memCache;
 
     public ParsingStoreBuilder() {
@@ -35,14 +34,19 @@ public class ParsingStoreBuilder<Raw, Parsed> {
     }
 
     @Nonnull
-    public ParsingStoreBuilder<Raw, Parsed> fetcher(final @Nonnull Fetcher<Raw> fetcher) {
+    public static <Raw, Parsed> ParsingStoreBuilder<Raw, Parsed> builder() {
+        return new ParsingStoreBuilder<>();
+    }
+
+    @Nonnull
+    public ParsingStoreBuilder<Raw, Parsed> fetcher(final @Nonnull Fetcher<Raw, BarCode> fetcher) {
         this.fetcher = fetcher;
         return this;
     }
 
     @Nonnull
     public ParsingStoreBuilder<Raw, Parsed> nonObservableFetcher(final @Nonnull Func1<BarCode, Raw> fetcher) {
-        this.fetcher = new Fetcher<Raw>() {
+        this.fetcher = new Fetcher<Raw, BarCode>() {
             @Nonnull
             @Override
             public Observable<Raw> fetch(final BarCode barCode) {
@@ -59,15 +63,15 @@ public class ParsingStoreBuilder<Raw, Parsed> {
     }
 
     @Nonnull
-    public ParsingStoreBuilder<Raw, Parsed> persister(final @Nonnull Persister<Raw> persister) {
+    public ParsingStoreBuilder<Raw, Parsed> persister(final @Nonnull Persister<Raw, BarCode> persister) {
         this.persister = persister;
         return this;
     }
 
     @Nonnull
-    public ParsingStoreBuilder<Raw, Parsed> persister(final @Nonnull DiskRead<Raw> diskRead,
-                                                      final @Nonnull DiskWrite<Raw> diskWrite) {
-        persister = new Persister<Raw>() {
+    public ParsingStoreBuilder<Raw, Parsed> persister(final @Nonnull DiskRead<Raw, BarCode> diskRead,
+                                                      final @Nonnull DiskWrite<Raw, BarCode> diskWrite) {
+        persister = new Persister<Raw, BarCode>() {
             @Nonnull
             @Override
             public Observable<Raw> read(BarCode barCode) {
@@ -98,15 +102,10 @@ public class ParsingStoreBuilder<Raw, Parsed> {
     }
 
     @Nonnull
-    public ParsingStoreBuilder<Raw, Parsed> parsers(final @Nonnull List<Parser> parsers) {
+    public ParsingStoreBuilder<Raw, Parsed> parsers(final @Nonnull List<Parser<Raw, Parsed>> parsers) {
         this.parsers.clear();
         this.parsers.addAll(parsers);
         return this;
-    }
-
-    @Nonnull
-    public static <Raw, Parsed> ParsingStoreBuilder<Raw, Parsed> builder() {
-        return new ParsingStoreBuilder<>();
     }
 
     @Nonnull
@@ -121,8 +120,8 @@ public class ParsingStoreBuilder<Raw, Parsed> {
             persister = new NoopPersister<>();
         }
 
-        Parser<Raw, Parsed> multiParser = new MultiParser<>(parsers);
-        RealInternalStore<Raw, Parsed> realInternalStore;
+        Parser<Raw, Parsed> multiParser = new MultiParser<Raw, Parsed>(parsers);
+        RealInternalStore<Raw, Parsed, BarCode> realInternalStore;
 
         if (memCache == null) {
             realInternalStore = new RealInternalStore<>(fetcher, persister, multiParser);
@@ -130,6 +129,6 @@ public class ParsingStoreBuilder<Raw, Parsed> {
             realInternalStore = new RealInternalStore<>(fetcher, persister, multiParser, memCache);
         }
 
-        return new RealStore<>(realInternalStore);
+        return new ProxyStore<>(realInternalStore);
     }
 }

--- a/store/src/main/java/com/nytimes/android/external/store/base/impl/ProxyStore.java
+++ b/store/src/main/java/com/nytimes/android/external/store/base/impl/ProxyStore.java
@@ -1,69 +1,65 @@
 package com.nytimes.android.external.store.base.impl;
 
-import javax.annotation.Nonnull;
 
 import com.nytimes.android.external.cache.Cache;
 import com.nytimes.android.external.store.base.Fetcher;
 import com.nytimes.android.external.store.base.InternalStore;
 import com.nytimes.android.external.store.base.Parser;
 import com.nytimes.android.external.store.base.Persister;
-import com.nytimes.android.external.store.base.beta.Store;
+import com.nytimes.android.external.store.base.Store;
 import com.nytimes.android.external.store.util.NoopParserFunc;
 import com.nytimes.android.external.store.util.NoopPersister;
+
+import org.jetbrains.annotations.NotNull;
 
 import rx.Observable;
 import rx.functions.Func1;
 
-public class RealStore<Parsed, Key> implements Store<Parsed, Key> {
+@Deprecated
+public class ProxyStore<Parsed> implements Store<Parsed> {
 
-    private final InternalStore<Parsed, Key> internalStore;
+    private final InternalStore<Parsed, BarCode> internalStore;
 
-    RealStore(InternalStore<Parsed, Key> internalStore) {
+    ProxyStore(InternalStore<Parsed, BarCode> internalStore) {
         this.internalStore = internalStore;
     }
 
-    public RealStore(Fetcher<Parsed, Key> fetcher) {
-        internalStore = new RealInternalStore<>(fetcher, new NoopPersister<Parsed, Key>(),
+    public ProxyStore(Fetcher<Parsed, BarCode> fetcher) {
+        internalStore = new RealInternalStore<>(fetcher, new NoopPersister<Parsed, BarCode>(),
                 new NoopParserFunc<Parsed, Parsed>());
     }
 
-    public RealStore(Fetcher<Parsed, Key> fetcher, Persister<Parsed, Key> persister) {
+    public ProxyStore(Fetcher<Parsed, BarCode> fetcher, Persister<Parsed, BarCode> persister) {
         internalStore = new RealInternalStore<>(fetcher, persister,
                 new NoopParserFunc<Parsed, Parsed>());
     }
 
-    public <Raw> RealStore(Fetcher<Raw, Key> fetcher,
-                           Persister<Raw, Key> persister,
-                           Parser<Raw, Parsed> parser) {
+    public <Raw> ProxyStore(Fetcher<Raw, BarCode> fetcher,
+                            Persister<Raw, BarCode> persister,
+                            Parser<Raw, Parsed> parser) {
         internalStore = new RealInternalStore<>(fetcher, persister, parser);
     }
 
 
-    public <Raw> RealStore(Fetcher<Raw, Key> fetcher,
-                           Persister<Raw, Key> persister,
-                           Func1<Raw, Parsed> parser, Cache<Key, Observable<Parsed>> memCache) {
+    public <Raw> ProxyStore(Fetcher<Raw, BarCode> fetcher,
+                            Persister<Raw, BarCode> persister,
+                            Func1<Raw, Parsed> parser, Cache<BarCode, Observable<Parsed>> memCache) {
         internalStore = new RealInternalStore<>(fetcher, persister, parser, memCache);
     }
 
 
-    public <Raw> RealStore(Fetcher<Raw, Key> fetcher,
-                           Persister<Raw, Key> persister,
-                           Cache<Key, Observable<Parsed>> memCache) {
+    public <Raw> ProxyStore(Fetcher<Raw, BarCode> fetcher,
+                            Persister<Raw, BarCode> persister,
+                            Cache<BarCode, Observable<Parsed>> memCache) {
         internalStore = new RealInternalStore<>(fetcher, persister, new NoopParserFunc<Raw, Parsed>(), memCache);
     }
 
 
-    @Nonnull
+    @NotNull
     @Override
-    public Observable<Parsed> get(@Nonnull final Key barCode) {
+    public Observable<Parsed> get(@NotNull final BarCode barCode) {
         return internalStore.get(barCode);
     }
-
-    @Override
-    public Observable<Parsed> getRefreshing(@Nonnull key barCode) {
-        return internalStore.getRefreshing(barCode);
-    }
-
 
     /**
      * Will check to see if there exists an in flight observable and return it before
@@ -71,21 +67,21 @@ public class RealStore<Parsed, Key> implements Store<Parsed, Key> {
      *
      * @return data from fetch and store it in memory and persister
      */
-    @Nonnull
+    @NotNull
     @Override
-    public Observable<Parsed> fetch(@Nonnull final Key barCode) {
+    public Observable<Parsed> fetch(@NotNull final BarCode barCode) {
         return internalStore.fetch(barCode);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Observable<Parsed> stream() {
         return internalStore.stream();
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public Observable<Parsed> stream(Key id) {
+    public Observable<Parsed> stream(BarCode id) {
         return internalStore.stream(id);
     }
 
@@ -100,16 +96,16 @@ public class RealStore<Parsed, Key> implements Store<Parsed, Key> {
      * @param barCode of data to clear
      */
     @Override
-    public void clearMemory(@Nonnull final Key barCode) {
+    public void clearMemory(@NotNull final BarCode barCode) {
         internalStore.clearMemory(barCode);
     }
 
-    protected Observable<Parsed> memory(@Nonnull Key id) {
+    protected Observable<Parsed> memory(@NotNull BarCode id) {
         return internalStore.memory(id);
     }
 
-    @Nonnull
-    protected Observable<Parsed> disk(@Nonnull Key id) {
+    @NotNull
+    protected Observable<Parsed> disk(@NotNull BarCode id) {
         return internalStore.disk(id);
     }
 

--- a/store/src/main/java/com/nytimes/android/external/store/base/impl/ProxyStore.java
+++ b/store/src/main/java/com/nytimes/android/external/store/base/impl/ProxyStore.java
@@ -10,7 +10,7 @@ import com.nytimes.android.external.store.base.Store;
 import com.nytimes.android.external.store.util.NoopParserFunc;
 import com.nytimes.android.external.store.util.NoopPersister;
 
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 import rx.Observable;
 import rx.functions.Func1;
@@ -55,10 +55,16 @@ public class ProxyStore<Parsed> implements Store<Parsed> {
     }
 
 
-    @NotNull
+    @Nonnull
     @Override
-    public Observable<Parsed> get(@NotNull final BarCode barCode) {
+    public Observable<Parsed> get(@Nonnull final BarCode barCode) {
         return internalStore.get(barCode);
+    }
+
+    @Nonnull
+    @Override
+    public Observable<Parsed> getRefreshing(@Nonnull BarCode key) {
+        return internalStore.getRefreshing(key);
     }
 
     /**
@@ -67,19 +73,19 @@ public class ProxyStore<Parsed> implements Store<Parsed> {
      *
      * @return data from fetch and store it in memory and persister
      */
-    @NotNull
+    @Nonnull
     @Override
-    public Observable<Parsed> fetch(@NotNull final BarCode barCode) {
+    public Observable<Parsed> fetch(@Nonnull final BarCode barCode) {
         return internalStore.fetch(barCode);
     }
 
-    @NotNull
+    @Nonnull
     @Override
     public Observable<Parsed> stream() {
         return internalStore.stream();
     }
 
-    @NotNull
+    @Nonnull
     @Override
     public Observable<Parsed> stream(BarCode id) {
         return internalStore.stream(id);
@@ -96,16 +102,16 @@ public class ProxyStore<Parsed> implements Store<Parsed> {
      * @param barCode of data to clear
      */
     @Override
-    public void clearMemory(@NotNull final BarCode barCode) {
+    public void clearMemory(@Nonnull final BarCode barCode) {
         internalStore.clearMemory(barCode);
     }
 
-    protected Observable<Parsed> memory(@NotNull BarCode id) {
+    protected Observable<Parsed> memory(@Nonnull BarCode id) {
         return internalStore.memory(id);
     }
 
-    @NotNull
-    protected Observable<Parsed> disk(@NotNull BarCode id) {
+    @Nonnull
+    protected Observable<Parsed> disk(@Nonnull BarCode id) {
         return internalStore.disk(id);
     }
 

--- a/store/src/main/java/com/nytimes/android/external/store/base/impl/RealInternalStore.java
+++ b/store/src/main/java/com/nytimes/android/external/store/base/impl/RealInternalStore.java
@@ -351,7 +351,6 @@ final class RealInternalStore<Raw, Parsed, Key> implements InternalStore<Parsed,
      * @return memory persister size
      */
     private long getCacheSize() {
-//        return memCache.size();
         return 100;
     }
 

--- a/store/src/main/java/com/nytimes/android/external/store/base/impl/RealInternalStore.java
+++ b/store/src/main/java/com/nytimes/android/external/store/base/impl/RealInternalStore.java
@@ -237,7 +237,6 @@ final class RealInternalStore<Raw, Parsed, Key> implements InternalStore<Parsed,
                 .flatMap(new Func1<Raw, Observable<Parsed>>() {
                     @Override
                     public Observable<Parsed> call(Raw raw) {
-                        //Log.i(TAG,"writing and then reading from Persister");
                         return persister().write(barCode, raw)
                                 .flatMap(new Func1<Boolean, Observable<Parsed>>() {
                                     @Nonnull
@@ -264,7 +263,6 @@ final class RealInternalStore<Raw, Parsed, Key> implements InternalStore<Parsed,
     }
 
     void notifySubscribers(Parsed data) {
-        //Log.d(TAG,"notify stream subscribers of fresh data");
         subject.onNext(data);
     }
 

--- a/store/src/main/java/com/nytimes/android/external/store/base/impl/RealStore.java
+++ b/store/src/main/java/com/nytimes/android/external/store/base/impl/RealStore.java
@@ -1,7 +1,5 @@
 package com.nytimes.android.external.store.base.impl;
 
-import javax.annotation.Nonnull;
-
 import com.nytimes.android.external.cache.Cache;
 import com.nytimes.android.external.store.base.Fetcher;
 import com.nytimes.android.external.store.base.InternalStore;
@@ -10,6 +8,8 @@ import com.nytimes.android.external.store.base.Persister;
 import com.nytimes.android.external.store.base.beta.Store;
 import com.nytimes.android.external.store.util.NoopParserFunc;
 import com.nytimes.android.external.store.util.NoopPersister;
+
+import javax.annotation.Nonnull;
 
 import rx.Observable;
 import rx.functions.Func1;
@@ -60,7 +60,7 @@ public class RealStore<Parsed, Key> implements Store<Parsed, Key> {
     }
 
     @Override
-    public Observable<Parsed> getRefreshing(@Nonnull key barCode) {
+    public Observable<Parsed> getRefreshing(@Nonnull Key barCode) {
         return internalStore.getRefreshing(barCode);
     }
 

--- a/store/src/main/java/com/nytimes/android/external/store/base/impl/RealStoreBuilder.java
+++ b/store/src/main/java/com/nytimes/android/external/store/base/impl/RealStoreBuilder.java
@@ -10,10 +10,10 @@ import com.nytimes.android.external.store.base.Persister;
 import com.nytimes.android.external.store.base.beta.Store;
 import com.nytimes.android.external.store.util.NoopPersister;
 
-import org.jetbrains.annotations.NotNull;
-
 import java.util.ArrayList;
 import java.util.List;
+
+import javax.annotation.Nonnull;
 
 import rx.Observable;
 
@@ -26,34 +26,34 @@ public class RealStoreBuilder<Raw, Parsed, Key> {
     private Cache<Key, Observable<Parsed>> memCache;
     private Fetcher<Raw, Key> fetcher;
 
-    @NotNull
+    @Nonnull
     public static <Raw, Parsed, Key> RealStoreBuilder<Raw, Parsed, Key> builder() {
         return new RealStoreBuilder<>();
     }
 
-    @NotNull
-    public RealStoreBuilder<Raw, Parsed, Key> fetcher(final @NotNull Fetcher<Raw, Key> fetcher) {
+    @Nonnull
+    public RealStoreBuilder<Raw, Parsed, Key> fetcher(final @Nonnull Fetcher<Raw, Key> fetcher) {
         this.fetcher = fetcher;
         return this;
     }
 
-    @NotNull
-    public RealStoreBuilder<Raw, Parsed, Key> persister(final @NotNull Persister<Raw, Key> persister) {
+    @Nonnull
+    public RealStoreBuilder<Raw, Parsed, Key> persister(final @Nonnull Persister<Raw, Key> persister) {
         this.persister = persister;
         return this;
     }
 
-    @NotNull
-    public RealStoreBuilder<Raw, Parsed, Key> persister(final @NotNull DiskRead<Raw, Key> diskRead,
-                                                        final @NotNull DiskWrite<Raw, Key> diskWrite) {
+    @Nonnull
+    public RealStoreBuilder<Raw, Parsed, Key> persister(final @Nonnull DiskRead<Raw, Key> diskRead,
+                                                        final @Nonnull DiskWrite<Raw, Key> diskWrite) {
         persister = new Persister<Raw, Key>() {
-            @NotNull
+            @Nonnull
             @Override
             public Observable<Raw> read(Key barCode) {
                 return diskRead.read(barCode);
             }
 
-            @NotNull
+            @Nonnull
             @Override
             public Observable<Boolean> write(Key barCode, Raw raw) {
                 return diskWrite.write(barCode, raw);
@@ -62,27 +62,27 @@ public class RealStoreBuilder<Raw, Parsed, Key> {
         return this;
     }
 
-    @NotNull
-    public RealStoreBuilder<Raw, Parsed, Key> parser(final @NotNull Parser<Raw, Parsed> parser) {
+    @Nonnull
+    public RealStoreBuilder<Raw, Parsed, Key> parser(final @Nonnull Parser<Raw, Parsed> parser) {
         this.parsers.clear();
         this.parsers.add(parser);
         return this;
     }
 
-    @NotNull
-    public RealStoreBuilder<Raw, Parsed, Key> parsers(final @NotNull List<Parser> parsers) {
+    @Nonnull
+    public RealStoreBuilder<Raw, Parsed, Key> parsers(final @Nonnull List<Parser> parsers) {
         this.parsers.clear();
         this.parsers.addAll(parsers);
         return this;
     }
 
-    @NotNull
+    @Nonnull
     public RealStoreBuilder<Raw, Parsed, Key> memory(Cache<Key, Observable<Parsed>> memCache) {
         this.memCache = memCache;
         return this;
     }
 
-    @NotNull
+    @Nonnull
     public Store<Parsed, Key> open() {
         if (persister == null) {
             persister = new NoopPersister<>();

--- a/store/src/main/java/com/nytimes/android/external/store/base/impl/RealStoreBuilder.java
+++ b/store/src/main/java/com/nytimes/android/external/store/base/impl/RealStoreBuilder.java
@@ -1,0 +1,102 @@
+package com.nytimes.android.external.store.base.impl;
+
+
+import com.nytimes.android.external.cache.Cache;
+import com.nytimes.android.external.store.base.DiskRead;
+import com.nytimes.android.external.store.base.DiskWrite;
+import com.nytimes.android.external.store.base.Fetcher;
+import com.nytimes.android.external.store.base.Parser;
+import com.nytimes.android.external.store.base.Persister;
+import com.nytimes.android.external.store.base.beta.Store;
+import com.nytimes.android.external.store.util.NoopPersister;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import rx.Observable;
+
+/**
+ * Builder where there parser is used.
+ */
+public class RealStoreBuilder<Raw, Parsed, Key> {
+    private final List<Parser> parsers = new ArrayList<>();
+    private Persister<Raw, Key> persister;
+    private Cache<Key, Observable<Parsed>> memCache;
+    private Fetcher<Raw, Key> fetcher;
+
+    @NotNull
+    public static <Raw, Parsed, Key> RealStoreBuilder<Raw, Parsed, Key> builder() {
+        return new RealStoreBuilder<>();
+    }
+
+    @NotNull
+    public RealStoreBuilder<Raw, Parsed, Key> fetcher(final @NotNull Fetcher<Raw, Key> fetcher) {
+        this.fetcher = fetcher;
+        return this;
+    }
+
+    @NotNull
+    public RealStoreBuilder<Raw, Parsed, Key> persister(final @NotNull Persister<Raw, Key> persister) {
+        this.persister = persister;
+        return this;
+    }
+
+    @NotNull
+    public RealStoreBuilder<Raw, Parsed, Key> persister(final @NotNull DiskRead<Raw, Key> diskRead,
+                                                        final @NotNull DiskWrite<Raw, Key> diskWrite) {
+        persister = new Persister<Raw, Key>() {
+            @NotNull
+            @Override
+            public Observable<Raw> read(Key barCode) {
+                return diskRead.read(barCode);
+            }
+
+            @NotNull
+            @Override
+            public Observable<Boolean> write(Key barCode, Raw raw) {
+                return diskWrite.write(barCode, raw);
+            }
+        };
+        return this;
+    }
+
+    @NotNull
+    public RealStoreBuilder<Raw, Parsed, Key> parser(final @NotNull Parser<Raw, Parsed> parser) {
+        this.parsers.clear();
+        this.parsers.add(parser);
+        return this;
+    }
+
+    @NotNull
+    public RealStoreBuilder<Raw, Parsed, Key> parsers(final @NotNull List<Parser> parsers) {
+        this.parsers.clear();
+        this.parsers.addAll(parsers);
+        return this;
+    }
+
+    @NotNull
+    public RealStoreBuilder<Raw, Parsed, Key> memory(Cache<Key, Observable<Parsed>> memCache) {
+        this.memCache = memCache;
+        return this;
+    }
+
+    @NotNull
+    public Store<Parsed, Key> open() {
+        if (persister == null) {
+            persister = new NoopPersister<>();
+        }
+
+        Parser<Raw, Parsed> multiParser = new MultiParser<>(parsers);
+        RealInternalStore<Raw, Parsed, Key> realInternalStore;
+
+        if (memCache == null) {
+            realInternalStore = new RealInternalStore<>(fetcher, persister, multiParser);
+        } else {
+            realInternalStore = new RealInternalStore<>(fetcher, persister, multiParser, memCache);
+        }
+
+        return new RealStore<>(realInternalStore);
+    }
+}

--- a/store/src/main/java/com/nytimes/android/external/store/base/impl/StoreBuilder.java
+++ b/store/src/main/java/com/nytimes/android/external/store/base/impl/StoreBuilder.java
@@ -10,7 +10,7 @@ import com.nytimes.android.external.store.base.Store;
 import com.nytimes.android.external.store.util.NoopParserFunc;
 import com.nytimes.android.external.store.util.NoopPersister;
 
-import org.jetbrains.annotations.Nonnull;
+import javax.annotation.Nonnull;
 
 import rx.Observable;
 import rx.annotations.Beta;

--- a/store/src/main/java/com/nytimes/android/external/store/base/impl/StoreBuilder.java
+++ b/store/src/main/java/com/nytimes/android/external/store/base/impl/StoreBuilder.java
@@ -50,7 +50,9 @@ public final class StoreBuilder<Raw> {
         return new RealStoreBuilder<>();
     }
 
-    //Please Use fromTypes to build Stores, allowing customization of Barcode Type
+    /**
+     * Please Use fromTypes to build Stores, allowing customization of Barcode Type
+     */
     @Deprecated
     @Nonnull
     public StoreBuilder<Raw> fetcher(final @Nonnull Fetcher<Raw, BarCode> fetcher) {
@@ -58,7 +60,9 @@ public final class StoreBuilder<Raw> {
         return this;
     }
 
-    //Please Use fromTypes to build Stores, allowing customization of Barcode Type
+    /**
+     * Please Use fromTypes to build Stores, allowing customization of Barcode Type
+     */
     @Deprecated
     @Nonnull
     public StoreBuilder<Raw> persister(final @Nonnull Persister<Raw, BarCode> persister) {
@@ -66,7 +70,9 @@ public final class StoreBuilder<Raw> {
         return this;
     }
 
-    //Please Use fromTypes to build Stores, allowing customization of Barcode Type
+    /**
+     * Please Use fromTypes to build Stores, allowing customization of Barcode Type
+     */
     @Deprecated
     @Nonnull
     public StoreBuilder<Raw> persister(final @Nonnull DiskRead<Raw, BarCode> diskRead,
@@ -87,7 +93,9 @@ public final class StoreBuilder<Raw> {
         return this;
     }
 
-    //Please Use fromTypes to build Stores, allowing customization of Barcode Type
+    /**
+     * Please Use fromTypes to build Stores, allowing customization of Barcode Type
+     */
     @Nonnull
     @Deprecated
     public StoreBuilder<Raw> memory(Cache<BarCode, Observable<Raw>> memCache) {
@@ -95,7 +103,9 @@ public final class StoreBuilder<Raw> {
         return this;
     }
 
-    //Please Use fromTypes to build Stores, allowing customization of Barcode Type
+    /**
+     * Please Use fromTypes to build Stores, allowing customization of Barcode Type
+     */
     @Nonnull
     @Deprecated
     public Store<Raw> open() {

--- a/store/src/main/java/com/nytimes/android/external/store/util/NoopPersister.java
+++ b/store/src/main/java/com/nytimes/android/external/store/util/NoopPersister.java
@@ -2,7 +2,6 @@ package com.nytimes.android.external.store.util;
 
 
 import com.nytimes.android.external.store.base.Persister;
-import com.nytimes.android.external.store.base.impl.BarCode;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -14,19 +13,19 @@ import rx.Observable;
 /**
  * Pass-through diskdao for stores that don't want to use persister
  */
-public class NoopPersister<Raw> implements Persister<Raw> {
-    private final ConcurrentMap<BarCode, Raw> networkResponses = new ConcurrentHashMap<>();
+public class NoopPersister<Raw, Key> implements Persister<Raw, Key> {
+    private final ConcurrentMap<Key, Raw> networkResponses = new ConcurrentHashMap<>();
 
     @Nonnull
     @Override
-    public Observable<Raw> read(BarCode barCode) {
+    public Observable<Raw> read(Key barCode) {
         Raw raw = networkResponses.get(barCode);
         return raw == null ? Observable.<Raw>empty() : Observable.just(raw);
     }
 
     @Nonnull
     @Override
-    public Observable<Boolean> write(BarCode barCode, Raw raw) {
+    public Observable<Boolean> write(Key barCode, Raw raw) {
         networkResponses.put(barCode, raw);
         return Observable.just(true);
     }

--- a/store/src/test/java/com/nytimes/android/external/store/ClearStoreMemoryTest.java
+++ b/store/src/test/java/com/nytimes/android/external/store/ClearStoreMemoryTest.java
@@ -25,7 +25,7 @@ public class ClearStoreMemoryTest {
     public void setUp() {
         networkCalls = 0;
         store = StoreBuilder.<Integer>builder()
-                .fetcher(new Fetcher<Integer>() {
+                .fetcher(new Fetcher<Integer, BarCode>() {
                     @Nonnull
                     @Override
                     public Observable<Integer> fetch(BarCode barCode) {

--- a/store/src/test/java/com/nytimes/android/external/store/DontCacheErrorsTest.java
+++ b/store/src/test/java/com/nytimes/android/external/store/DontCacheErrorsTest.java
@@ -22,7 +22,7 @@ public class DontCacheErrorsTest {
     @Before
     public void setUp() {
         store = StoreBuilder.<Integer>builder()
-                .fetcher(new Fetcher<Integer>() {
+                .fetcher(new Fetcher<Integer, BarCode>() {
                     @Nonnull
                     @Override
                     public Observable<Integer> fetch(BarCode barCode) {

--- a/store/src/test/java/com/nytimes/android/external/store/GetRefreshingTest.java
+++ b/store/src/test/java/com/nytimes/android/external/store/GetRefreshingTest.java
@@ -26,7 +26,7 @@ public class GetRefreshingTest {
     public void setUp() {
         networkCalls = 0;
         store = StoreBuilder.<Integer>builder()
-                .fetcher(new Fetcher<Integer>() {
+                .fetcher(new Fetcher<Integer, BarCode>() {
                     @Nonnull
                     @Override
                     public Observable<Integer> fetch(BarCode barCode) {

--- a/store/src/test/java/com/nytimes/android/external/store/SampleParsingStore.java
+++ b/store/src/test/java/com/nytimes/android/external/store/SampleParsingStore.java
@@ -3,12 +3,15 @@ package com.nytimes.android.external.store;
 import com.nytimes.android.external.store.base.Fetcher;
 import com.nytimes.android.external.store.base.Parser;
 import com.nytimes.android.external.store.base.Persister;
-import com.nytimes.android.external.store.base.impl.RealStore;
+import com.nytimes.android.external.store.base.impl.BarCode;
+import com.nytimes.android.external.store.base.impl.ProxyStore;
 
 
-public class SampleParsingStore extends RealStore<String> {
+public class SampleParsingStore extends ProxyStore<String> {
 
-    public SampleParsingStore(Fetcher<String> fetcher, Persister<String> persister, Parser<String, String> parser) {
+    public SampleParsingStore(Fetcher<String, BarCode> fetcher,
+                              Persister<String, BarCode> persister,
+                              Parser<String, String> parser) {
         super(fetcher, persister, parser);
     }
 }

--- a/store/src/test/java/com/nytimes/android/external/store/SampleStore.java
+++ b/store/src/test/java/com/nytimes/android/external/store/SampleStore.java
@@ -2,15 +2,12 @@ package com.nytimes.android.external.store;
 
 import com.nytimes.android.external.store.base.Fetcher;
 import com.nytimes.android.external.store.base.Persister;
-import com.nytimes.android.external.store.base.impl.RealStore;
-import com.nytimes.android.external.store.util.NoopPersister;
+import com.nytimes.android.external.store.base.impl.BarCode;
+import com.nytimes.android.external.store.base.impl.ProxyStore;
 
 
-public class SampleStore extends RealStore<String> {
-    public SampleStore(Fetcher<String> fetcher, Persister<String> persister) {
+public class SampleStore extends ProxyStore<String> {
+    public SampleStore(Fetcher<String, BarCode> fetcher, Persister<String, BarCode> persister) {
         super(fetcher, persister);
-    }
-    public SampleStore(Fetcher<String> fetcher) {
-        super(fetcher, new NoopPersister<String>());
     }
 }

--- a/store/src/test/java/com/nytimes/android/external/store/SequentialTest.java
+++ b/store/src/test/java/com/nytimes/android/external/store/SequentialTest.java
@@ -25,7 +25,7 @@ public class SequentialTest {
     public void setUp() {
         networkCalls = 0;
         store = StoreBuilder.<Integer>builder()
-                .fetcher(new Fetcher<Integer>() {
+                .fetcher(new Fetcher<Integer, BarCode>() {
                     @Nonnull
                     @Override
                     public Observable<Integer> fetch(BarCode barCode) {

--- a/store/src/test/java/com/nytimes/android/external/store/StoreTest.java
+++ b/store/src/test/java/com/nytimes/android/external/store/StoreTest.java
@@ -144,9 +144,8 @@ public class StoreTest {
     @Test
     public void testNoopAndDefault() {
 
-        NoopPersister<String, BarCode> persister = spy(new NoopPersister<String, BarCode>());
+        Persister<String, BarCode> persister = spy(new NoopPersister<String, BarCode>());
         ProxyStore<String> simpleStore = new SampleStore(fetcher, persister);
-        simpleStore.clearMemory();
 
 
         when(fetcher.fetch(barCode))

--- a/store/src/test/java/com/nytimes/android/external/store/StoreTest.java
+++ b/store/src/test/java/com/nytimes/android/external/store/StoreTest.java
@@ -6,7 +6,7 @@ import com.nytimes.android.external.store.base.Fetcher;
 import com.nytimes.android.external.store.base.Persister;
 import com.nytimes.android.external.store.base.Store;
 import com.nytimes.android.external.store.base.impl.BarCode;
-import com.nytimes.android.external.store.base.impl.RealStore;
+import com.nytimes.android.external.store.base.impl.ProxyStore;
 import com.nytimes.android.external.store.base.impl.StoreBuilder;
 import com.nytimes.android.external.store.util.NoopPersister;
 
@@ -34,11 +34,10 @@ public class StoreTest {
     private static final String DISK = "disk";
     private static final String NETWORK = "fetch";
     private static final String MEMORY = "memory";
-
     @Mock
-    Fetcher<String> fetcher;
+    Fetcher<String, BarCode> fetcher;
     @Mock
-    Persister<String> persister;
+    Persister<String, BarCode> persister;
     private final BarCode barCode = new BarCode("key", "value");
     private final AtomicInteger counter = new AtomicInteger(0);
 
@@ -123,7 +122,7 @@ public class StoreTest {
     @Test
     public void testSubclass() {
 
-        Store<String> simpleStore = new SampleStore(fetcher, persister);
+        ProxyStore<String> simpleStore = new SampleStore(fetcher, persister);
         simpleStore.clearMemory();
 
         when(fetcher.fetch(barCode))
@@ -145,8 +144,10 @@ public class StoreTest {
     @Test
     public void testNoopAndDefault() {
 
-        NoopPersister<String> persister = spy(new NoopPersister<String>());
-        Store<String> simpleStore = new RealStore<>(fetcher, persister);
+        NoopPersister<String, BarCode> persister = spy(new NoopPersister<String, BarCode>());
+        ProxyStore<String> simpleStore = new SampleStore(fetcher, persister);
+        simpleStore.clearMemory();
+
 
         when(fetcher.fetch(barCode))
                 .thenReturn(Observable.just(NETWORK));

--- a/store/src/test/java/com/nytimes/android/external/store/StoreWithParserTest.java
+++ b/store/src/test/java/com/nytimes/android/external/store/StoreWithParserTest.java
@@ -3,7 +3,7 @@ package com.nytimes.android.external.store;
 import com.nytimes.android.external.store.base.Fetcher;
 import com.nytimes.android.external.store.base.Parser;
 import com.nytimes.android.external.store.base.Persister;
-import com.nytimes.android.external.store.base.Store;
+import com.nytimes.android.external.store.base.beta.Store;
 import com.nytimes.android.external.store.base.impl.BarCode;
 import com.nytimes.android.external.store.base.impl.ParsingStoreBuilder;
 
@@ -22,11 +22,10 @@ public class StoreWithParserTest {
 
     private static final String DISK = "persister";
     private static final String NETWORK = "fetch";
-
     @Mock
-    Fetcher<String> fetcher;
+    Fetcher<String, BarCode> fetcher;
     @Mock
-    Persister<String> persister;
+    Persister<String, BarCode> persister;
     @Mock
     Parser<String, String> parser;
 
@@ -37,7 +36,7 @@ public class StoreWithParserTest {
         MockitoAnnotations.initMocks(this);
 
 
-        Store<String> simpleStore = ParsingStoreBuilder.<String, String>builder()
+        Store<String, BarCode> simpleStore = ParsingStoreBuilder.<String, String>builder()
                 .persister(persister)
                 .fetcher(fetcher)
                 .parser(parser)
@@ -66,7 +65,7 @@ public class StoreWithParserTest {
     public void testSubclass() {
         MockitoAnnotations.initMocks(this);
 
-        Store<String> simpleStore = new SampleParsingStore(fetcher, persister, parser);
+        Store<String, BarCode> simpleStore = new SampleParsingStore(fetcher, persister, parser);
 
         when(fetcher.fetch(barCode))
                 .thenReturn(Observable.just(NETWORK));

--- a/store/src/test/java/com/nytimes/android/external/store/TypeStoreTest.java
+++ b/store/src/test/java/com/nytimes/android/external/store/TypeStoreTest.java
@@ -8,10 +8,11 @@ import com.nytimes.android.external.store.base.beta.Store;
 import com.nytimes.android.external.store.base.impl.StoreBuilder;
 
 import org.assertj.core.api.Assertions;
-import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 
 import java.util.Date;
+
+import javax.annotation.Nonnull;
 
 import rx.Observable;
 
@@ -24,20 +25,20 @@ public class TypeStoreTest {
         Store<Date, Integer> store = StoreBuilder
                 .fromTypes(Integer.class, String.class, Date.class)
                 .fetcher(new Fetcher<String, Integer>() {
-                    @NotNull
+                    @Nonnull
                     @Override
                     public Observable<String> fetch(Integer barCode) {
                         return Observable.just(String.valueOf(barCode));
                     }
                 })
                 .persister(new Persister<String, Integer>() {
-                    @NotNull
+                    @Nonnull
                     @Override
                     public Observable<String> read(Integer barCode) {
                         return Observable.just(String.valueOf(barCode));
                     }
 
-                    @NotNull
+                    @Nonnull
                     @Override
                     public Observable<Boolean> write(Integer barCode, String s) {
                         return Observable.empty();

--- a/store/src/test/java/com/nytimes/android/external/store/TypeStoreTest.java
+++ b/store/src/test/java/com/nytimes/android/external/store/TypeStoreTest.java
@@ -1,0 +1,58 @@
+package com.nytimes.android.external.store;
+
+
+import com.nytimes.android.external.store.base.Fetcher;
+import com.nytimes.android.external.store.base.Parser;
+import com.nytimes.android.external.store.base.Persister;
+import com.nytimes.android.external.store.base.beta.Store;
+import com.nytimes.android.external.store.base.impl.StoreBuilder;
+
+import org.assertj.core.api.Assertions;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Test;
+
+import java.util.Date;
+
+import rx.Observable;
+
+public class TypeStoreTest {
+
+    public static final Date DATE = new Date();
+
+    @Test
+    public void simpleTest() {
+        Store<Date, Integer> store = StoreBuilder
+                .fromTypes(Integer.class, String.class, Date.class)
+                .fetcher(new Fetcher<String, Integer>() {
+                    @NotNull
+                    @Override
+                    public Observable<String> fetch(Integer barCode) {
+                        return Observable.just(String.valueOf(barCode));
+                    }
+                })
+                .persister(new Persister<String, Integer>() {
+                    @NotNull
+                    @Override
+                    public Observable<String> read(Integer barCode) {
+                        return Observable.just(String.valueOf(barCode));
+                    }
+
+                    @NotNull
+                    @Override
+                    public Observable<Boolean> write(Integer barCode, String s) {
+                        return Observable.empty();
+                    }
+                })
+                .parser(new Parser<String, Date>() {
+                    @Override
+                    public Date call(String s) {
+                        return DATE;
+                    }
+                })
+                .open();
+
+        Date result = store.get(5).toBlocking().first();
+        Assertions.assertThat(result).isEqualTo(DATE);
+
+    }
+}

--- a/store/src/test/java/com/nytimes/android/external/store/util/NoopPersisterTest.java
+++ b/store/src/test/java/com/nytimes/android/external/store/util/NoopPersisterTest.java
@@ -13,7 +13,7 @@ public class NoopPersisterTest {
     @Test
     public void writeReadTest() {
 
-        NoopPersister<String> persister = new NoopPersister<>();
+        NoopPersister<String, BarCode> persister = new NoopPersister<>();
         boolean success = persister.write(barCode, "foo").toBlocking().first();
         assertThat(success).isTrue();
         String rawValue = persister.read(barCode).toBlocking().first();


### PR DESCRIPTION
close #23 

This is a breaking change. It will be open a bit for discussion. This change introduces a new StoreBuilder architecture. Rather than having a `StoreBuilder` and a `ParsingStoreBuilder` with different generics (1 vs 2).  We now have a single StoreBuilder that can take in 3 types:  Raw, Parsed, Key (BarCode).  Api looks like:
```java
Store<Date, Integer> store = StoreBuilder
               .fromTypes(Key.class, Parsed.class, Raw.class)
               .fetcher()
               .parser()
               .persister()
```

This allows us to support from 1 to 3 types being passed in.  The problem with this apporach is that we need to change the signature of fetcher<Raw> to instead be fetcher<Raw,Barcode> to support a custom `Barcode` type to be passed in, similar with the `Persister` and the generic supporting `Store` as seen above.

Opening this PR for discussion. External opinions are greatly appreciated