### PR TITLE
fixes inflight caching errors

### DIFF
--- a/store/src/main/java/com/nytimes/android/external/store/base/impl/RealInternalStore.java
+++ b/store/src/main/java/com/nytimes/android/external/store/base/impl/RealInternalStore.java
@@ -217,6 +217,12 @@ final class RealInternalStore<Raw, Parsed> implements InternalStore<Parsed> {
                         notifySubscribers(data);
                     }
                 })
+                .doOnError(new Action1<Throwable>() {
+                    @Override
+                    public void call(Throwable throwable) {
+                        inFlightRequests.invalidate(barCode);
+                    }
+                })
                 .cache();
     }
 

--- a/store/src/test/java/com/nytimes/android/external/store/DontCacheErrorsTest.java
+++ b/store/src/test/java/com/nytimes/android/external/store/DontCacheErrorsTest.java
@@ -1,0 +1,58 @@
+package com.nytimes.android.external.store;
+
+import com.nytimes.android.external.store.base.Fetcher;
+import com.nytimes.android.external.store.base.Store;
+import com.nytimes.android.external.store.base.impl.BarCode;
+import com.nytimes.android.external.store.base.impl.StoreBuilder;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.Callable;
+
+import javax.annotation.Nonnull;
+
+import rx.Observable;
+
+public class DontCacheErrorsTest {
+
+    private boolean shouldThrow;
+    private Store<Integer> store;
+
+    @Before
+    public void setUp() {
+        store = StoreBuilder.<Integer>builder()
+                .fetcher(new Fetcher<Integer>() {
+                    @Nonnull
+                    @Override
+                    public Observable<Integer> fetch(BarCode barCode) {
+                        return Observable.fromCallable(new Callable<Integer>() {
+                            @Override
+                            public Integer call() {
+                                if (shouldThrow) {
+                                    throw new RuntimeException();
+                                } else {
+                                    return 0;
+                                }
+                            }
+                        });
+                    }
+                })
+                .open();
+    }
+
+    @Test
+    public void testStoreDoesntCacheErrors() throws InterruptedException {
+        BarCode barcode = new BarCode("bar", "code");
+
+        shouldThrow = true;
+        store.get(barcode).test()
+                .awaitTerminalEvent()
+                .assertError(Exception.class);
+
+        shouldThrow = false;
+        store.get(barcode).test()
+                .awaitTerminalEvent()
+                .assertNoErrors();
+    }
+}


### PR DESCRIPTION
errors are great, retaining an Observable that emits an error and then sharing it again is not great.  This pr closes #100 which was reported by @PaulWoitaschek 💯 thanks again.