### PR TITLE
Feature/clear all cache

### DIFF
--- a/filesystem/src/test/java/com/nytimes/android/external/fs/StoreRefreshWhenStaleTest.java
+++ b/filesystem/src/test/java/com/nytimes/android/external/fs/StoreRefreshWhenStaleTest.java
@@ -90,7 +90,7 @@ public class StoreRefreshWhenStaleTest {
         verify(fetcher, times(0)).fetch(barCode);
         verify(persister, times(1)).getRecordState(barCode);
 
-        store.clearMemory(barCode);
+        store.clear(barCode);
         result = store.get(barCode).test().awaitTerminalEvent().getOnNextEvents().get(0);
         assertThat(result).isEqualTo(disk2);
         verify(fetcher, times(0)).fetch(barCode);

--- a/store/src/main/java/com/nytimes/android/external/store/base/Clearable.java
+++ b/store/src/main/java/com/nytimes/android/external/store/base/Clearable.java
@@ -1,9 +1,10 @@
 package com.nytimes.android.external.store.base;
 
-/**
- * Created by 206847 on 2/7/17.
- */
 
+/**
+ * Persisters should implement Clearable if they want store.clear(key) to also clear the persister
+ * @param <T> Type of key/request param in store
+ */
 public interface Clearable<T> {
     void clear(T key);
 }

--- a/store/src/main/java/com/nytimes/android/external/store/base/Clearable.java
+++ b/store/src/main/java/com/nytimes/android/external/store/base/Clearable.java
@@ -1,0 +1,9 @@
+package com.nytimes.android.external.store.base;
+
+/**
+ * Created by 206847 on 2/7/17.
+ */
+
+public interface Clearable<T> {
+    void clear(T key);
+}

--- a/store/src/main/java/com/nytimes/android/external/store/base/beta/Store.java
+++ b/store/src/main/java/com/nytimes/android/external/store/base/beta/Store.java
@@ -45,7 +45,8 @@ public interface Store<T, V> {
     /**
      * @return an Observable that emits "fresh" new response from the store that hit the fetcher
      * WARNING: stream is an endless observable, be careful when combining
-     * with operators that expect an OnComplete event     */
+     * with operators that expect an OnComplete event
+     */
     @Nonnull
     Observable<T> stream();
 
@@ -73,10 +74,15 @@ public interface Store<T, V> {
     @Deprecated
     void clearMemory(@Nonnull V key);
 
+    /**
+     * purges all entries from memory and disk cache
+     * Persister will only be cleared if they implements Clearable
+     */
     void clear();
 
     /**
      * Purge a particular entry from memory and disk cache.
+     * Persister will only be cleared if they implements Clearable
      */
     void clear(@Nonnull V key);
 

--- a/store/src/main/java/com/nytimes/android/external/store/base/beta/Store.java
+++ b/store/src/main/java/com/nytimes/android/external/store/base/beta/Store.java
@@ -43,8 +43,9 @@ public interface Store<T, V> {
     Observable<T> fetch(@Nonnull V key);
 
     /**
-     * @return an Observable that emits new items when they arrive.
-     */
+     * @return an Observable that emits "fresh" new response from the store that hit the fetcher
+     * WARNING: stream is an endless observable, be careful when combining
+     * with operators that expect an OnComplete event     */
     @Nonnull
     Observable<T> stream();
 
@@ -63,12 +64,21 @@ public interface Store<T, V> {
     /**
      * Clear the memory cache of all entries
      */
+    @Deprecated
     void clearMemory();
 
     /**
      * Purge a particular entry from memory cache.
      */
+    @Deprecated
     void clearMemory(@Nonnull V key);
+
+    void clear();
+
+    /**
+     * Purge a particular entry from memory and disk cache.
+     */
+    void clear(@Nonnull V key);
 
 
 }

--- a/store/src/main/java/com/nytimes/android/external/store/base/impl/ProxyStore.java
+++ b/store/src/main/java/com/nytimes/android/external/store/base/impl/ProxyStore.java
@@ -109,6 +109,16 @@ public class ProxyStore<Parsed> implements Store<Parsed> {
         internalStore.clearMemory(barCode);
     }
 
+    @Override
+    public void clear() {
+        internalStore.clear();
+    }
+
+    @Override
+    public void clear(@Nonnull BarCode key) {
+        internalStore.clear(key);
+    }
+
     protected Observable<Parsed> memory(@Nonnull BarCode id) {
         return internalStore.memory(id);
     }

--- a/store/src/main/java/com/nytimes/android/external/store/base/impl/RealStore.java
+++ b/store/src/main/java/com/nytimes/android/external/store/base/impl/RealStore.java
@@ -107,6 +107,17 @@ public class RealStore<Parsed, Key> implements Store<Parsed, Key> {
         internalStore.clearMemory(barCode);
     }
 
+    @Override
+    public void clear() {
+        internalStore.clear();
+    }
+
+    @Override
+    public void clear(@Nonnull Key key) {
+        internalStore.clear();
+
+    }
+
     protected Observable<Parsed> memory(@Nonnull Key id) {
         return internalStore.memory(id);
     }

--- a/store/src/main/java/com/nytimes/android/external/store/util/NoopPersister.java
+++ b/store/src/main/java/com/nytimes/android/external/store/util/NoopPersister.java
@@ -1,6 +1,7 @@
 package com.nytimes.android.external.store.util;
 
 
+import com.nytimes.android.external.store.base.Clearable;
 import com.nytimes.android.external.store.base.Persister;
 
 import java.util.concurrent.ConcurrentHashMap;
@@ -13,8 +14,8 @@ import rx.Observable;
 /**
  * Pass-through diskdao for stores that don't want to use persister
  */
-public class NoopPersister<Raw, Key> implements Persister<Raw, Key> {
-    private final ConcurrentMap<Key, Raw> networkResponses = new ConcurrentHashMap<>();
+public class NoopPersister<Raw, Key> implements Persister<Raw, Key>, Clearable<Key> {
+    protected final ConcurrentMap<Key, Raw> networkResponses = new ConcurrentHashMap<>();
 
     @Nonnull
     @Override
@@ -28,5 +29,10 @@ public class NoopPersister<Raw, Key> implements Persister<Raw, Key> {
     public Observable<Boolean> write(Key barCode, Raw raw) {
         networkResponses.put(barCode, raw);
         return Observable.just(true);
+    }
+
+    @Override
+    public void clear(Key key) {
+        networkResponses.remove(key);
     }
 }

--- a/store/src/test/java/com/nytimes/android/external/store/ClearStoreMemoryTest.java
+++ b/store/src/test/java/com/nytimes/android/external/store/ClearStoreMemoryTest.java
@@ -42,7 +42,7 @@ public class ClearStoreMemoryTest {
 
     @Test
     public void testClearSingleBarCode() {
-        // one request should produce one call
+        //one request should produce one call
         BarCode barcode = new BarCode("type", "key");
         store.get(barcode).test().awaitTerminalEvent();
         assertThat(networkCalls).isEqualTo(1);
@@ -58,14 +58,14 @@ public class ClearStoreMemoryTest {
         BarCode b1 = new BarCode("type1", "key1");
         BarCode b2 = new BarCode("type2", "key2");
 
-        // each request should produce one call
+        //each request should produce one call
         store.get(b1).test().awaitTerminalEvent();
         store.get(b2).test().awaitTerminalEvent();
         assertThat(networkCalls).isEqualTo(2);
 
         store.clearMemory();
 
-        // after everything is cleared each request should produce another 2 calls
+        //after everything is cleared each request should produce another 2 calls
         store.get(b1).test().awaitTerminalEvent();
         store.get(b2).test().awaitTerminalEvent();
         assertThat(networkCalls).isEqualTo(4);

--- a/store/src/test/java/com/nytimes/android/external/store/StoreTest.java
+++ b/store/src/test/java/com/nytimes/android/external/store/StoreTest.java
@@ -123,7 +123,7 @@ public class StoreTest {
     public void testSubclass() {
 
         ProxyStore<String> simpleStore = new SampleStore(fetcher, persister);
-        simpleStore.clearMemory();
+        simpleStore.clear();
 
         when(fetcher.fetch(barCode))
                 .thenReturn(Observable.just(NETWORK));


### PR DESCRIPTION
close #102 

This PR introduces a `Clearable` interface & 2 public methods in store: `clear(key)/clear()` which works as:

If a `Persister` instance implements `Clearable` then the disk cache will be cleared otherwise memory only will be cleared. The functionality we are trying to achieve is clearing all caches allowing for getRefreshing to truly sync back to the server.