### PR TITLE
Manually instantiate UTF-8 as a charset instead of using StandardCharsets

### DIFF
--- a/middleware/src/main/java/com/nytimes/android/external/store/middleware/GsonSourceParser.java
+++ b/middleware/src/main/java/com/nytimes/android/external/store/middleware/GsonSourceParser.java
@@ -14,7 +14,7 @@ import javax.inject.Inject;
 import okio.BufferedSource;
 
 import static com.nytimes.android.external.cache.Preconditions.checkNotNull;
-import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.charset.Charset;
 
 
 /**
@@ -43,7 +43,7 @@ public class GsonSourceParser<Parsed> implements Parser<BufferedSource, Parsed> 
 
     @Override
     public Parsed call(@Nonnull BufferedSource source) {
-        try (InputStreamReader reader = new InputStreamReader(source.inputStream(), UTF_8)) {
+        try (InputStreamReader reader = new InputStreamReader(source.inputStream(), Charset.forName("UTF-8")) {
             return gson.fromJson(reader, type);
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/middleware/src/main/java/com/nytimes/android/external/store/middleware/GsonSourceParser.java
+++ b/middleware/src/main/java/com/nytimes/android/external/store/middleware/GsonSourceParser.java
@@ -43,7 +43,7 @@ public class GsonSourceParser<Parsed> implements Parser<BufferedSource, Parsed> 
 
     @Override
     public Parsed call(@Nonnull BufferedSource source) {
-        try (InputStreamReader reader = new InputStreamReader(source.inputStream(), Charset.forName("UTF-8")) {
+        try (InputStreamReader reader = new InputStreamReader(source.inputStream(), Charset.forName("UTF-8"))) {
             return gson.fromJson(reader, type);
         } catch (IOException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
As `StandardCharsets` is only available in API 19 and above.