### PR TITLE
Do not depend on lint task if it does not exist.

### DIFF
--- a/gradle/checkstyle.gradle
+++ b/gradle/checkstyle.gradle
@@ -1,5 +1,7 @@
 apply plugin: 'checkstyle'
-assemble.dependsOn('lint')
+if(tasks.findByName('lint') != null) {
+    assemble.dependsOn('lint')
+}
 check.dependsOn('checkstyle')
 
 


### PR DESCRIPTION
The `java` plugin does not have a `lint` task, so trying to build the project locally fails for me because it is not found. I don't know how Travis has managed to make it work so far tho