### PR TITLE
[WIP] read all for a particular barcode type

### DIFF
--- a/filesystem/src/main/java/com/nytimes/android/external/fs/BarCodePathResolver.java
+++ b/filesystem/src/main/java/com/nytimes/android/external/fs/BarCodePathResolver.java
@@ -7,7 +7,7 @@ import javax.annotation.Nonnull;
 class BarCodePathResolver implements PathResolver<BarCode> {
     @Nonnull
     @Override
-    public String resolve(@Nonnull BarCode key) {
-        return key.toString();
+    public String resolve(@Nonnull BarCode barCode) {
+        return barCode.getType()+"/"+barCode.getKey();
     }
 }

--- a/filesystem/src/main/java/com/nytimes/android/external/fs/FSReader.java
+++ b/filesystem/src/main/java/com/nytimes/android/external/fs/FSReader.java
@@ -10,6 +10,7 @@ import javax.annotation.Nonnull;
 import okio.BufferedSource;
 import rx.Emitter;
 import rx.Observable;
+import rx.exceptions.Exceptions;
 import rx.functions.Action1;
 import rx.functions.Func1;
 
@@ -63,7 +64,7 @@ public class FSReader<T> implements DiskRead<BufferedSource, T> {
                             try {
                                 return fileSystem.read(s);
                             } catch (FileNotFoundException e) {
-                                throw new RuntimeException(e);
+                                throw Exceptions.propagate(e);
                             }
                         }
                 });

--- a/filesystem/src/main/java/com/nytimes/android/external/fs/FSReader.java
+++ b/filesystem/src/main/java/com/nytimes/android/external/fs/FSReader.java
@@ -11,6 +11,7 @@ import okio.BufferedSource;
 import rx.Emitter;
 import rx.Observable;
 import rx.functions.Action1;
+import rx.functions.Func1;
 
 /**
  * FSReader is used when persisting from file system
@@ -36,7 +37,7 @@ public class FSReader<T> implements DiskRead<BufferedSource, T> {
             public void call(Emitter<BufferedSource> emitter) {
                 String resolvedKey = pathResolver.resolve(key);
                 boolean exists = fileSystem.exists(resolvedKey);
-              
+
                 if (exists) {
                     try {
                         BufferedSource bufferedSource = fileSystem.read(resolvedKey);
@@ -50,5 +51,21 @@ public class FSReader<T> implements DiskRead<BufferedSource, T> {
                 }
             }
         }, Emitter.BackpressureMode.NONE);
+    }
+
+
+    public Observable<BufferedSource>  readAll(@Nonnull final String type) throws FileNotFoundException {
+        return Observable
+                .from(fileSystem.list(type))
+                .map(new Func1<String, BufferedSource>() {
+                    @Override
+                    public BufferedSource call(String s) {
+                            try {
+                                return fileSystem.read(s);
+                            } catch (FileNotFoundException e) {
+                                throw new RuntimeException(e);
+                            }
+                        }
+                });
     }
 }

--- a/filesystem/src/main/java/com/nytimes/android/external/fs/FileSystemPersister.java
+++ b/filesystem/src/main/java/com/nytimes/android/external/fs/FileSystemPersister.java
@@ -31,6 +31,8 @@ public final class FileSystemPersister<T> implements Persister<BufferedSource, T
         return new FileSystemPersister<>(fileSystem, pathResolver);
     }
 
+
+
     @Nonnull
     @Override
     public Observable<BufferedSource> read(@Nonnull final T key) {

--- a/filesystem/src/main/java/com/nytimes/android/external/fs/SourceFileReader.java
+++ b/filesystem/src/main/java/com/nytimes/android/external/fs/SourceFileReader.java
@@ -11,10 +11,7 @@ import javax.annotation.Nonnull;
 
 import okio.BufferedSource;
 
-import static com.nytimes.android.external.fs.SourcePersister.pathForBarcode;
-
 public class SourceFileReader extends FSReader<BarCode> implements DiskRead<BufferedSource, BarCode> {
-
     public SourceFileReader(FileSystem fileSystem) {
         super(fileSystem, new BarCodePathResolver());
     }
@@ -24,6 +21,7 @@ public class SourceFileReader extends FSReader<BarCode> implements DiskRead<Buff
     public RecordState getRecordState(@Nonnull BarCode barCode,
                                       @Nonnull TimeUnit expirationUnit,
                                       long expirationDuration) {
-        return fileSystem.getRecordState(expirationUnit, expirationDuration, pathForBarcode(barCode));
+        String path = new BarCodePathResolver().resolve(barCode);
+        return fileSystem.getRecordState(expirationUnit, expirationDuration, path);
     }
 }

--- a/filesystem/src/main/java/com/nytimes/android/external/fs/SourcePersister.java
+++ b/filesystem/src/main/java/com/nytimes/android/external/fs/SourcePersister.java
@@ -5,6 +5,8 @@ import com.nytimes.android.external.fs.filesystem.FileSystem;
 import com.nytimes.android.external.store.base.Persister;
 import com.nytimes.android.external.store.base.impl.BarCode;
 
+import java.io.FileNotFoundException;
+
 import javax.annotation.Nonnull;
 import javax.inject.Inject;
 
@@ -38,11 +40,6 @@ public class SourcePersister implements Persister<BufferedSource, BarCode> {
     }
 
     @Nonnull
-    static String pathForBarcode(@Nonnull BarCode barCode) {
-        return barCode.getType() + barCode.getKey();
-    }
-
-    @Nonnull
     @Override
     public Observable<BufferedSource> read(@Nonnull final BarCode barCode) {
         return sourceFileReader.read(barCode);
@@ -52,6 +49,11 @@ public class SourcePersister implements Persister<BufferedSource, BarCode> {
     @Override
     public Observable<Boolean> write(@Nonnull final BarCode barCode, @Nonnull final BufferedSource data) {
         return sourceFileWriter.write(barCode, data);
+    }
+
+    @Nonnull
+    public Observable<BufferedSource> readAll(String type) throws FileNotFoundException {
+       return sourceFileReader.readAll(type);
     }
 
 }

--- a/filesystem/src/test/java/com/nytimes/android/external/fs/FSReaderTest.java
+++ b/filesystem/src/test/java/com/nytimes/android/external/fs/FSReaderTest.java
@@ -1,0 +1,48 @@
+package com.nytimes.android.external.fs;
+
+import com.nytimes.android.external.fs.filesystem.FileSystem;
+import com.nytimes.android.external.fs.filesystem.FileSystemFactory;
+import com.nytimes.android.external.store.base.impl.BarCode;
+
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import okio.BufferedSource;
+import okio.Okio;
+import rx.observables.BlockingObservable;
+
+import static com.google.common.base.Charsets.UTF_8;
+import static com.google.common.io.Files.createTempDir;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FSReaderTest {
+
+    public static final String TYPE = "type";
+    public static final String CHALLAH = "Challah";
+    public static final String CHALLAH_CHALLAH = "Challah_CHALLAH";
+    private BarCodePathResolver barCodePathResolver=new BarCodePathResolver();
+
+    @Test
+    public void readAll() throws IOException {
+        //create 2 barcodes with same type
+        BarCode barCode = new BarCode(TYPE, "key");
+        BarCode barCode1 = new BarCode(TYPE, "key2");
+
+        FileSystem fileSystem = FileSystemFactory.create(createTempDir());
+        //write different data to File System for each barcode
+        fileSystem.write(barCodePathResolver.resolve(barCode), source(CHALLAH));
+        fileSystem.write(barCodePathResolver.resolve(barCode), source(CHALLAH_CHALLAH));
+        FSReader<BarCode> reader = new FSReader<>(fileSystem, barCodePathResolver);
+        //read back all values for the TYPE
+        BlockingObservable<BufferedSource> observable = reader.readAll(TYPE).toBlocking();
+        assertThat(observable.first()).isEqualTo(CHALLAH);
+        assertThat(observable.last()).isEqualTo(CHALLAH_CHALLAH);
+    }
+
+    private static BufferedSource source(String data) {
+        return Okio.buffer(Okio.source(new ByteArrayInputStream(data.getBytes(UTF_8))));
+    }
+
+}

--- a/filesystem/src/test/java/com/nytimes/android/external/fs/SourcePersisterTest.java
+++ b/filesystem/src/test/java/com/nytimes/android/external/fs/SourcePersisterTest.java
@@ -31,7 +31,7 @@ public class SourcePersisterTest {
 
     private SourcePersister sourcePersister;
     private final BarCode simple = new BarCode("type", "key");
-
+    private final BarCodePathResolver resolver=new BarCodePathResolver();
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
@@ -51,7 +51,7 @@ public class SourcePersisterTest {
     @Test
     public void readDoesNotExist() throws FileNotFoundException {
         expectedException.expect(NoSuchElementException.class);
-        when(fileSystem.exists(SourcePersister.pathForBarcode(simple)))
+        when(fileSystem.exists(resolver.resolve(simple)))
                 .thenReturn(false);
 
         sourcePersister.read(simple).toBlocking().single();
@@ -64,6 +64,6 @@ public class SourcePersisterTest {
 
     @Test
     public void pathForBarcode() {
-        assertThat(SourcePersister.pathForBarcode(simple)).isEqualTo("typekey");
+        assertThat(resolver.resolve(simple)).isEqualTo("typekey");
     }
 }

--- a/store/src/main/java/com/nytimes/android/external/store/base/impl/BarCode.java
+++ b/store/src/main/java/com/nytimes/android/external/store/base/impl/BarCode.java
@@ -74,9 +74,6 @@ public final class BarCode implements Serializable {
 
     @Override
     public String toString() {
-        return "BarCode{" +
-                "key='" + key + '\'' +
-                ", type='" + type + '\'' +
-                '}';
+        return getType() + getKey();
     }
 }


### PR DESCRIPTION
closes #172 
@riclage is this what you were thinking?

There is a breaking change in barcode resolution inside of SourceReader we were toStringing the barcode sometimes and other times we were appending key and type together. This PR unifies the behavior to be the same. 