### PR TITLE
Standardize store.stream() to emit only new items

### DIFF
--- a/store/src/main/java/com/nytimes/android/external/store/base/impl/RealInternalStore.java
+++ b/store/src/main/java/com/nytimes/android/external/store/base/impl/RealInternalStore.java
@@ -23,7 +23,6 @@ import rx.functions.Action0;
 import rx.functions.Action1;
 import rx.functions.Func0;
 import rx.functions.Func1;
-import rx.subjects.BehaviorSubject;
 import rx.subjects.PublishSubject;
 
 import static com.nytimes.android.external.store.base.impl.StoreUtil.persisterIsStale;
@@ -47,7 +46,7 @@ final class RealInternalStore<Raw, Parsed, Key> implements InternalStore<Parsed,
 
     private final PublishSubject<Key> refreshSubject = PublishSubject.create();
     private Fetcher<Raw, Key> fetcher;
-    private BehaviorSubject<Parsed> subject;
+    private PublishSubject<Parsed> subject;
 
     RealInternalStore(Fetcher<Raw, Key> fetcher,
                       Persister<Raw, Key> persister,
@@ -79,7 +78,7 @@ final class RealInternalStore<Raw, Parsed, Key> implements InternalStore<Parsed,
         initMemCache(memoryPolicy);
         initFlightRequests(memoryPolicy);
 
-        subject = BehaviorSubject.create();
+        subject = PublishSubject.create();
     }
 
     private void initFlightRequests(MemoryPolicy memoryPolicy) {
@@ -313,15 +312,7 @@ final class RealInternalStore<Raw, Parsed, Key> implements InternalStore<Parsed,
     @Nonnull
     @Override
     public Observable<Parsed> stream(@Nonnull Key key) {
-
-        Observable<Parsed> stream = subject.asObservable();
-
-        //If nothing was emitted through the subject yet, start stream with get() value
-        if (!subject.hasValue()) {
-            return stream.startWith(get(key));
-        }
-
-        return stream;
+        return subject.asObservable().startWith(get(key));
     }
 
     @Nonnull

--- a/store/src/main/java/com/nytimes/android/external/store/base/impl/RealInternalStore.java
+++ b/store/src/main/java/com/nytimes/android/external/store/base/impl/RealInternalStore.java
@@ -312,7 +312,7 @@ final class RealInternalStore<Raw, Parsed, Key> implements InternalStore<Parsed,
     @Nonnull
     @Override
     public Observable<Parsed> stream(@Nonnull Key key) {
-        return subject.asObservable().startWith(get(key));
+        return subject.startWith(get(key));
     }
 
     @Nonnull

--- a/store/src/test/java/com/nytimes/android/external/store/StreamTest.java
+++ b/store/src/test/java/com/nytimes/android/external/store/StreamTest.java
@@ -1,0 +1,70 @@
+package com.nytimes.android.external.store;
+
+import com.nytimes.android.external.store.base.Fetcher;
+import com.nytimes.android.external.store.base.Persister;
+import com.nytimes.android.external.store.base.impl.BarCode;
+import com.nytimes.android.external.store.base.impl.Store;
+import com.nytimes.android.external.store.base.impl.StoreBuilder;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import rx.Observable;
+import rx.observers.AssertableSubscriber;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StreamTest {
+
+    private static final String TEST_ITEM = "test";
+
+    @Mock
+    Fetcher<String, BarCode> fetcher;
+    @Mock
+    Persister<String, BarCode> persister;
+
+    private final BarCode barCode = new BarCode("key", "value");
+
+    private Store<String, BarCode> store;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+
+        store = StoreBuilder.<String>barcode()
+                .persister(persister)
+                .fetcher(fetcher)
+                .open();
+
+        when(fetcher.fetch(barCode))
+                .thenReturn(Observable.just(TEST_ITEM));
+
+        when(persister.read(barCode))
+                .thenReturn(Observable.<String>empty())
+                .thenReturn(Observable.just(TEST_ITEM));
+
+        when(persister.write(barCode, TEST_ITEM))
+                .thenReturn(Observable.just(true));
+    }
+
+    @Test
+    public void testStream() {
+        AssertableSubscriber<String> streamObservable = store.stream().test();
+        assertThat(streamObservable.getValueCount()).isEqualTo(0);
+        store.get(barCode).subscribe();
+        assertThat(streamObservable.getValueCount()).isEqualTo(1);
+    }
+
+    @Test
+    public void testStreamEmitsOnlyFreshData() {
+        store.get(barCode).subscribe();
+        AssertableSubscriber<String> streamObservable = store.stream().test();
+        assertThat(streamObservable.getValueCount()).isEqualTo(0);
+    }
+}


### PR DESCRIPTION
This PR proposes migrating the subject within `RealInternalStore` which acts as a bridge for subscribers to `store.stream()` from a `BehaviorSubject` to a `PublishSubject`. 

This is a go at standardizing the behavior of `store.stream()` so that subscribers will passively stream only new items -- that is, items that are fetched after they subscribe.

If I'm understanding right, in the current implementation, subscribers to `store.stream()` on a new `RealStore` instance will passively stream new items. However, subscribers to an existing store instance where the fetcher has already returned at least one item, in addition to passively streaming new items, will also receive the last fetched item as cached by the `BehaviorSubject`. As of now, this cached item also persists through a `clear()` event.