### PR TITLE
expireAfterAccess added to MemoryPolicy

### DIFF
--- a/cache/src/main/java/com/nytimes/android/external/cache/LocalCache.java
+++ b/cache/src/main/java/com/nytimes/android/external/cache/LocalCache.java
@@ -4760,7 +4760,7 @@ class LocalCache<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V> 
     }
 
     /**
-     * Serializes the configuration of a LocalCache, reconsitituting it as an LoadingCache using
+     * Serializes the configuration of a LocalCache, reconstituting it as a LoadingCache using
      * CacheBuilder upon deserialization. An instance of this class is fit for use by the writeReplace
      * of LocalLoadingCache.
      * <p>

--- a/store/src/main/java/com/nytimes/android/external/store/base/impl/CacheFactory.java
+++ b/store/src/main/java/com/nytimes/android/external/store/base/impl/CacheFactory.java
@@ -20,18 +20,26 @@ final class CacheFactory {
                     .expireAfterWrite(StoreDefaults.getCacheTTL(), StoreDefaults.getCacheTTLTimeUnit())
                     .build();
         } else {
-            return CacheBuilder
-                    .newBuilder()
-                    .maximumSize(memoryPolicy.getMaxSize())
-                    .expireAfterWrite(memoryPolicy.getExpireAfter(), memoryPolicy.getExpireAfterTimeUnit())
-                    .build();
+            if (memoryPolicy.getExpireAfterAccess() == -1) {
+                return CacheBuilder
+                        .newBuilder()
+                        .maximumSize(memoryPolicy.getMaxSize())
+                        .expireAfterWrite(memoryPolicy.getExpireAfterWrite(), memoryPolicy.getExpireAfterTimeUnit())
+                        .build();
+            } else {
+                return CacheBuilder
+                        .newBuilder()
+                        .maximumSize(memoryPolicy.getMaxSize())
+                        .expireAfterAccess(memoryPolicy.getExpireAfterAccess(), memoryPolicy.getExpireAfterTimeUnit())
+                        .build();
+            }
         }
     }
 
     static <Key, Parsed> Cache<Key, Observable<Parsed>> createInflighter(MemoryPolicy memoryPolicy) {
         long expireAfterToSeconds = memoryPolicy == null ? StoreDefaults.getCacheTTLTimeUnit()
                 .toSeconds(StoreDefaults.getCacheTTL())
-                : memoryPolicy.getExpireAfterTimeUnit().toSeconds(memoryPolicy.getExpireAfter());
+                : memoryPolicy.getExpireAfterTimeUnit().toSeconds(memoryPolicy.getExpireAfterWrite());
         long maximumInFlightRequestsDuration = TimeUnit.MINUTES.toSeconds(1);
 
         if (expireAfterToSeconds > maximumInFlightRequestsDuration) {
@@ -41,7 +49,7 @@ final class CacheFactory {
                     .build();
         } else {
             long expireAfter = memoryPolicy == null ? StoreDefaults.getCacheTTL() :
-                    memoryPolicy.getExpireAfter();
+                    memoryPolicy.getExpireAfterWrite();
             TimeUnit expireAfterUnit = memoryPolicy == null ? StoreDefaults.getCacheTTLTimeUnit() :
                     memoryPolicy.getExpireAfterTimeUnit();
             return CacheBuilder.newBuilder()

--- a/store/src/main/java/com/nytimes/android/external/store/base/impl/CacheFactory.java
+++ b/store/src/main/java/com/nytimes/android/external/store/base/impl/CacheFactory.java
@@ -20,7 +20,7 @@ final class CacheFactory {
                     .expireAfterWrite(StoreDefaults.getCacheTTL(), StoreDefaults.getCacheTTLTimeUnit())
                     .build();
         } else {
-            if (memoryPolicy.getExpireAfterAccess() == -1) {
+            if (memoryPolicy.getExpireAfterAccess() == memoryPolicy.DEFAULT_POLICY) {
                 return CacheBuilder
                         .newBuilder()
                         .maximumSize(memoryPolicy.getMaxSize())

--- a/store/src/main/java/com/nytimes/android/external/store/base/impl/MemoryPolicy.java
+++ b/store/src/main/java/com/nytimes/android/external/store/base/impl/MemoryPolicy.java
@@ -17,12 +17,14 @@ import java.util.concurrent.TimeUnit;
  */
 public class MemoryPolicy {
 
-    private final long expireAfter;
+    private final long expireAfterWrite;
+    private final long expireAfterAccess;
     private final TimeUnit expireAfterTimeUnit;
     private final long maxSize;
 
-    MemoryPolicy(long expireAfter, TimeUnit expireAfterTimeUnit, long maxSize) {
-        this.expireAfter = expireAfter;
+    MemoryPolicy(long expireAfterWrite, long expireAfterAccess, TimeUnit expireAfterTimeUnit, long maxSize) {
+        this.expireAfterWrite = expireAfterWrite;
+        this.expireAfterAccess = expireAfterAccess;
         this.expireAfterTimeUnit = expireAfterTimeUnit;
         this.maxSize = maxSize;
     }
@@ -31,8 +33,12 @@ public class MemoryPolicy {
         return new MemoryPolicyBuilder();
     }
 
-    public long getExpireAfter() {
-        return expireAfter;
+    public long getExpireAfterWrite() {
+        return expireAfterWrite;
+    }
+
+    public long getExpireAfterAccess() {
+        return expireAfterAccess;
     }
 
     public TimeUnit getExpireAfterTimeUnit() {
@@ -44,16 +50,28 @@ public class MemoryPolicy {
     }
 
     public boolean isDefaultPolicy() {
-        return expireAfter == -1;
+        return expireAfterWrite == -1;
     }
 
     public static class MemoryPolicyBuilder {
-        private long expireAfter = -1;
+        private long expireAfterWrite = -1;
+        private long expireAfterAccess = -1;
         private TimeUnit expireAfterTimeUnit = TimeUnit.SECONDS;
         private long maxSize = 1;
 
-        public MemoryPolicyBuilder setExpireAfter(long expireAfter) {
-            this.expireAfter = expireAfter;
+        public MemoryPolicyBuilder setExpireAfterWrite(long expireAfterWrite) {
+            if (expireAfterAccess != -1) {
+                throw new IllegalStateException("Cannot set expireAfterWrite with expireAfterAccess already set");
+            }
+            this.expireAfterWrite = expireAfterWrite;
+            return this;
+        }
+
+        public MemoryPolicyBuilder setExpireAfterAccess(long expireAfterAccess) {
+            if (expireAfterWrite != -1) {
+                throw new IllegalStateException("Cannot set expireAfterAccess with expireAfterWrite already set");
+            }
+            this.expireAfterAccess = expireAfterAccess;
             return this;
         }
 
@@ -68,7 +86,8 @@ public class MemoryPolicy {
         }
 
         public MemoryPolicy build() {
-            return new MemoryPolicy(expireAfter, expireAfterTimeUnit, maxSize);
+
+            return new MemoryPolicy(expireAfterWrite, expireAfterAccess, expireAfterTimeUnit, maxSize);
         }
     }
 }

--- a/store/src/main/java/com/nytimes/android/external/store/base/impl/MemoryPolicy.java
+++ b/store/src/main/java/com/nytimes/android/external/store/base/impl/MemoryPolicy.java
@@ -21,7 +21,7 @@ public class MemoryPolicy {
     private final long expireAfterAccess;
     private final TimeUnit expireAfterTimeUnit;
     private final long maxSize;
-    private final long DEFAULT_POLICY = -1;
+    public final long DEFAULT_POLICY = -1;
 
     MemoryPolicy(long expireAfterWrite, long expireAfterAccess, TimeUnit expireAfterTimeUnit, long maxSize) {
         this.expireAfterWrite = expireAfterWrite;

--- a/store/src/main/java/com/nytimes/android/external/store/base/impl/MemoryPolicy.java
+++ b/store/src/main/java/com/nytimes/android/external/store/base/impl/MemoryPolicy.java
@@ -17,11 +17,11 @@ import java.util.concurrent.TimeUnit;
  */
 public class MemoryPolicy {
 
+    public static final long DEFAULT_POLICY = -1;
     private final long expireAfterWrite;
     private final long expireAfterAccess;
     private final TimeUnit expireAfterTimeUnit;
     private final long maxSize;
-    public final long DEFAULT_POLICY = -1;
 
     MemoryPolicy(long expireAfterWrite, long expireAfterAccess, TimeUnit expireAfterTimeUnit, long maxSize) {
         this.expireAfterWrite = expireAfterWrite;
@@ -55,13 +55,13 @@ public class MemoryPolicy {
     }
 
     public static class MemoryPolicyBuilder {
-        private long expireAfterWrite = -1;
-        private long expireAfterAccess = -1;
+        private long expireAfterWrite = DEFAULT_POLICY;
+        private long expireAfterAccess = DEFAULT_POLICY;
         private TimeUnit expireAfterTimeUnit = TimeUnit.SECONDS;
         private long maxSize = 1;
 
         public MemoryPolicyBuilder setExpireAfterWrite(long expireAfterWrite) {
-            if (expireAfterAccess != -1) {
+            if (expireAfterAccess != DEFAULT_POLICY) {
                 throw new IllegalStateException("Cannot set expireAfterWrite with expireAfterAccess already set");
             }
             this.expireAfterWrite = expireAfterWrite;
@@ -69,7 +69,7 @@ public class MemoryPolicy {
         }
 
         public MemoryPolicyBuilder setExpireAfterAccess(long expireAfterAccess) {
-            if (expireAfterWrite != -1) {
+            if (expireAfterWrite != DEFAULT_POLICY) {
                 throw new IllegalStateException("Cannot set expireAfterAccess with expireAfterWrite already set");
             }
             this.expireAfterAccess = expireAfterAccess;

--- a/store/src/main/java/com/nytimes/android/external/store/base/impl/MemoryPolicy.java
+++ b/store/src/main/java/com/nytimes/android/external/store/base/impl/MemoryPolicy.java
@@ -21,6 +21,7 @@ public class MemoryPolicy {
     private final long expireAfterAccess;
     private final TimeUnit expireAfterTimeUnit;
     private final long maxSize;
+    private final long DEFAULT_POLICY = -1;
 
     MemoryPolicy(long expireAfterWrite, long expireAfterAccess, TimeUnit expireAfterTimeUnit, long maxSize) {
         this.expireAfterWrite = expireAfterWrite;
@@ -50,7 +51,7 @@ public class MemoryPolicy {
     }
 
     public boolean isDefaultPolicy() {
-        return expireAfterWrite == -1;
+        return expireAfterWrite == DEFAULT_POLICY;
     }
 
     public static class MemoryPolicyBuilder {
@@ -86,7 +87,6 @@ public class MemoryPolicy {
         }
 
         public MemoryPolicy build() {
-
             return new MemoryPolicy(expireAfterWrite, expireAfterAccess, expireAfterTimeUnit, maxSize);
         }
     }

--- a/store/src/main/java/com/nytimes/android/external/store/util/NoopPersister.java
+++ b/store/src/main/java/com/nytimes/android/external/store/util/NoopPersister.java
@@ -22,7 +22,7 @@ public class NoopPersister<Raw, Key> implements Persister<Raw, Key>, Clearable<K
     NoopPersister(MemoryPolicy memoryPolicy) {
         this.networkResponses = CacheBuilder
             .newBuilder()
-            .expireAfterWrite(memoryPolicy.getExpireAfter(), memoryPolicy.getExpireAfterTimeUnit())
+            .expireAfterWrite(memoryPolicy.getExpireAfterWrite(), memoryPolicy.getExpireAfterTimeUnit())
             .build();
     }
 
@@ -37,7 +37,7 @@ public class NoopPersister<Raw, Key> implements Persister<Raw, Key>, Clearable<K
         if (memoryPolicy == null) {
             memPolicy = MemoryPolicy
                 .builder()
-                .setExpireAfter(TimeUnit.HOURS.toSeconds(24))
+                .setExpireAfterWrite(TimeUnit.HOURS.toSeconds(24))
                 .setExpireAfterTimeUnit(TimeUnit.SECONDS)
                 .build();
         } else {


### PR DESCRIPTION
- I'm using the `expireAfterAccess` logic already in `CacheBuilder`, I'm assuming that's what the task was to do, only added some configuration to `MemoryPolicy`
- I didn't write any additional tests, as I couldn't find any that tested the `expireAfterWrite` logic of `MemoryPolicy` (let me know if I should add some tests)
- Not allowing for a client to set both `expireAfterWrite` and `expireAfterAccess`