### PR TITLE
Add a missing Source.close() call (fixes #196)

### DIFF
--- a/filesystem/src/main/java/com/nytimes/android/external/fs/FSReader.java
+++ b/filesystem/src/main/java/com/nytimes/android/external/fs/FSReader.java
@@ -4,6 +4,7 @@ import com.nytimes.android.external.fs.filesystem.FileSystem;
 import com.nytimes.android.external.store.base.DiskRead;
 
 import java.io.FileNotFoundException;
+import java.io.IOException;
 
 import javax.annotation.Nonnull;
 
@@ -35,12 +36,21 @@ public class FSReader<T> implements DiskRead<BufferedSource, T> {
             String resolvedKey = pathResolver.resolve(key);
             boolean exists = fileSystem.exists(resolvedKey);
             if (exists) {
+                BufferedSource bufferedSource = null;
                 try {
-                    BufferedSource bufferedSource = fileSystem.read(resolvedKey);
+                    bufferedSource = fileSystem.read(resolvedKey);
                     emitter.onNext(bufferedSource);
                     emitter.onCompleted();
                 } catch (FileNotFoundException e) {
                     emitter.onError(e);
+                } finally {
+                    if (bufferedSource != null) {
+                        try {
+                            bufferedSource.close();
+                        } catch (IOException e) {
+                            e.printStackTrace(System.err);
+                        }
+                    }
                 }
             } else {
                 emitter.onError(new FileNotFoundException(ERROR_MESSAGE + resolvedKey));


### PR DESCRIPTION
#196 