### PR TITLE
Deprecate setExpireAfter and getExpireAfter

### DIFF
--- a/store/src/main/java/com/nytimes/android/external/store/base/impl/MemoryPolicy.java
+++ b/store/src/main/java/com/nytimes/android/external/store/base/impl/MemoryPolicy.java
@@ -34,6 +34,14 @@ public class MemoryPolicy {
         return new MemoryPolicyBuilder();
     }
 
+    /**
+     * @deprecated Use {@link MemoryPolicy#getExpireAfterWrite()} or {@link MemoryPolicy#getExpireAfterAccess()}.
+     */
+    @Deprecated
+    public long getExpireAfter() {
+        return expireAfterWrite;
+    }
+
     public long getExpireAfterWrite() {
         return expireAfterWrite;
     }
@@ -59,6 +67,15 @@ public class MemoryPolicy {
         private long expireAfterAccess = DEFAULT_POLICY;
         private TimeUnit expireAfterTimeUnit = TimeUnit.SECONDS;
         private long maxSize = 1;
+
+        /**
+         * @deprecated Use {@link MemoryPolicyBuilder#setExpireAfterWrite(long)} or
+         * {@link MemoryPolicyBuilder#setExpireAfterAccess(long)}.
+         */
+        @Deprecated
+        public MemoryPolicyBuilder setExpireAfter(long expireAfter) {
+            return setExpireAfterWrite(expireAfter);
+        }
 
         public MemoryPolicyBuilder setExpireAfterWrite(long expireAfterWrite) {
             if (expireAfterAccess != DEFAULT_POLICY) {


### PR DESCRIPTION
This PR deprecates `MemoryPolicy`'s `setExpireAfter` and `getExpireAfter` methods, which were replaced with `expireAfterWrite` and `expireAfterAccess` methods per #191.