### PR TITLE
Update to RxJava 1.3.0 and use stable create(Action)

### DIFF
--- a/buildsystem/dependencies.gradle
+++ b/buildsystem/dependencies.gradle
@@ -25,8 +25,8 @@ ext.versions = [
         butterKnife          : '7.0.1',
 
         // Reactive.
-        rxJava               : '1.2.6',
-        rxJavaProGuardRules  : '1.1.6.0',
+        rxJava               : '1.3.0',
+        rxJavaProGuardRules  : '1.3.0.0',
         rxJavaAsyncUtil      : '0.21.0',
         rxAndroid            : '1.2.1',
 

--- a/filesystem/src/main/java/com/nytimes/android/external/fs/FSReader.java
+++ b/filesystem/src/main/java/com/nytimes/android/external/fs/FSReader.java
@@ -32,7 +32,7 @@ public class FSReader<T> implements DiskRead<BufferedSource, T> {
     @Nonnull
     @Override
     public Observable<BufferedSource> read(@Nonnull final T key) {
-        return Observable.fromEmitter(emitter -> {
+        return Observable.create(emitter -> {
             String resolvedKey = pathResolver.resolve(key);
             boolean exists = fileSystem.exists(resolvedKey);
             if (exists) {

--- a/store/src/test/java/com/nytimes/android/external/store/StoreTest.java
+++ b/store/src/test/java/com/nytimes/android/external/store/StoreTest.java
@@ -81,7 +81,7 @@ public class StoreTest {
                 .open();
 
         Observable<String> networkObservable =
-                Observable.fromEmitter(emitter -> {
+                Observable.create(emitter -> {
                     if (counter.incrementAndGet() == 1) {
                         emitter.onNext(NETWORK);
 


### PR DESCRIPTION
`Observable.fromEmitter` was removed in 1.3.0.