### PR TITLE
Prepare next development version.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ allprojects {
 ext {
     // POM file
     GROUP = "com.nytimes.android"
-    VERSION_NAME = "0.0.1-SNAPSHOT"
+    VERSION_NAME = "3.0.0-alpha-SNAPSHOT"
     POM_PACKAGING = "pom"
     POM_DESCRIPTION = "Store3 is built with RxJava2"
 

--- a/gradle/deploy_snapshot.sh
+++ b/gradle/deploy_snapshot.sh
@@ -7,7 +7,7 @@
 
 SLUG="NYTimes/Store"
 JDK="oraclejdk8"
-BRANCH="develop"
+BRANCH="feature/rx2"
 
 set -e
 


### PR DESCRIPTION
Bumping the version to `3.0.0-alpha-SNAPSHOT` in order to double-check the snapshot in maven before releasing.