### PR TITLE
fix stream for a single barcode

### DIFF
--- a/filesystem/src/main/java/com/nytimes/android/external/fs3/SourcePersisterFactory.java
+++ b/filesystem/src/main/java/com/nytimes/android/external/fs3/SourcePersisterFactory.java
@@ -77,7 +77,4 @@ public final class SourcePersisterFactory {
         }
         return SourcePersister.create(fileSystem);
     }
-
-
-
 }

--- a/filesystem/src/main/java/com/nytimes/android/external/fs3/SourcePersisterFactory.java
+++ b/filesystem/src/main/java/com/nytimes/android/external/fs3/SourcePersisterFactory.java
@@ -78,4 +78,6 @@ public final class SourcePersisterFactory {
         return SourcePersister.create(fileSystem);
     }
 
+
+
 }

--- a/store/src/main/java/com/nytimes/android/external/store3/base/impl/Store.java
+++ b/store/src/main/java/com/nytimes/android/external/store3/base/impl/Store.java
@@ -52,11 +52,10 @@ public interface Store<T, V> {
 
     /**
      * Similar to  {@link Store#get(V) Store.get() }
-     * Rather than returning a single response, Stream will stay subscribed for future emissions to the Store
-     * NOTE: Stream will continue to get emissions for ANY keyAndRawType not just starting one
+     * Rather than returning a single response,
+     * Stream will stay subscribed for future emissions to the Store
+     * Errors will be dropped
      *
-     * @deprecated Use {@link Store#stream()}. If you need to start with the first value,
-     * use {@code store.stream().startWith(store.get(keyAndRawType))}
      */
     @Deprecated
     @Nonnull

--- a/store/src/main/java/com/nytimes/android/external/store3/base/impl/StoreUtil.java
+++ b/store/src/main/java/com/nytimes/android/external/store3/base/impl/StoreUtil.java
@@ -19,7 +19,7 @@ final class StoreUtil {
 
     @Nonnull
     static <Parsed, Key> ObservableTransformer<Parsed, Parsed>
-    repeatWhenCacheEvicted(PublishSubject<Key> refreshSubject, @Nonnull final Key keyForRepeat) {
+    repeatWhenSubjectEmits(PublishSubject<Key> refreshSubject, @Nonnull final Key keyForRepeat) {
         Observable<Key> filter = refreshSubject.filter(key -> key.equals(keyForRepeat));
         return RepeatWhenEmits.from(filter);
     }

--- a/store/src/test/java/com/nytimes/android/external/store3/StreamOneKeyTest.java
+++ b/store/src/test/java/com/nytimes/android/external/store3/StreamOneKeyTest.java
@@ -1,0 +1,85 @@
+package com.nytimes.android.external.store3;
+
+import com.nytimes.android.external.store3.base.Fetcher;
+import com.nytimes.android.external.store3.base.Persister;
+import com.nytimes.android.external.store3.base.impl.BarCode;
+import com.nytimes.android.external.store3.base.impl.Store;
+import com.nytimes.android.external.store3.base.impl.StoreBuilder;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import io.reactivex.Maybe;
+import io.reactivex.Single;
+import io.reactivex.observers.TestObserver;
+
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StreamOneKeyTest {
+
+    private static final String TEST_ITEM = "test";
+    private static final String TEST_ITEM2 = "test2";
+
+    @Mock
+    Fetcher<String, BarCode> fetcher;
+    @Mock
+    Persister<String, BarCode> persister;
+
+    private final BarCode barCode = new BarCode("key", "value");
+    private final BarCode barCode2 = new BarCode("key2", "value2");
+
+    private Store<String, BarCode> store;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+
+        store = StoreBuilder.<String>barcode()
+                .persister(persister)
+                .fetcher(fetcher)
+                .open();
+
+        when(fetcher.fetch(barCode))
+                .thenReturn(Single.just(TEST_ITEM))
+                .thenReturn(Single.just(TEST_ITEM2));
+
+        when(persister.read(barCode))
+                .thenReturn(Maybe.<String>empty())
+                .thenReturn(Maybe.just(TEST_ITEM))
+                .thenReturn(Maybe.just(TEST_ITEM2));
+
+        when(persister.write(barCode, TEST_ITEM))
+                .thenReturn(Single.just(true));
+        when(persister.write(barCode, TEST_ITEM2))
+                .thenReturn(Single.just(true));
+    }
+
+    @Test
+    public void testStream() {
+        TestObserver<String> streamObservable = store.stream(barCode).test();
+        //first time we subscribe to stream it will fail getting from memory & disk and instead
+        //fetch from network, write to disk and notifiy subscribers
+        streamObservable.assertValueCount(1);
+
+        store.clear();
+        //fetch should notify subscribers again
+        store.fetch(barCode).test().awaitCount(1);
+        streamObservable.assertValues(TEST_ITEM, TEST_ITEM2);
+
+        //get for another barcode should not trigger a stream for barcode1
+        when(fetcher.fetch(barCode2))
+                .thenReturn(Single.just(TEST_ITEM));
+        when(persister.read(barCode2))
+                .thenReturn(Maybe.empty())
+                .thenReturn(Maybe.just(TEST_ITEM));
+        when(persister.write(barCode2, TEST_ITEM))
+                .thenReturn(Single.just(true));
+        store.get(barCode2).test().awaitCount(1);
+        streamObservable.assertValueCount(2);
+    }
+}


### PR DESCRIPTION
This pr fixes the functionality of stream(key) which will now kick off a get request and then propogate a new network value anytime it comes through the store for the same key.

closes #112 