### PR TITLE
Upon calling fetch, notify the refresh subject.

### DIFF
--- a/store/src/main/java/com/nytimes/android/external/store/base/impl/RealInternalStore.java
+++ b/store/src/main/java/com/nytimes/android/external/store/base/impl/RealInternalStore.java
@@ -166,7 +166,8 @@ final class RealInternalStore<Raw, Parsed, Key> implements InternalStore<Parsed,
     @Nonnull
     @Override
     public Observable<Parsed> fetch(@Nonnull final Key key) {
-        return Observable.defer(() -> fetchAndPersist(key));
+        return Observable.defer(() -> fetchAndPersist(key))
+                .doOnCompleted(() -> notifyRefresh(key));
     }
 
     /**


### PR DESCRIPTION
To ensure getRefreshing receives the latest data, the refresh mechanism has to be triggered.