### PR TITLE
Accept SDK license with travis + bump sample app to 3.0.0-beta

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ android:
   - build-tools-26.0.1
   - android-25
   - extra-android-m2repository
+  licenses:
+  - 'android-sdk-license-.+'
 script:
 - ./gradlew check --stacktrace
 after_success:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,9 +48,9 @@ dependencies {
     annotationProcessor libraries.immutablesValue // <-- for annotation processor
     compileOnly libraries.immutablesValue // <-- for annotation API
     compileOnly libraries.immutablesGson // for annotations
-    implementation 'com.nytimes.android:store3:3.0.0-alpha'
-    implementation 'com.nytimes.android:cache3:3.0.0-alpha'
-    implementation 'com.nytimes.android:middleware3:3.0.0-alpha'
-    implementation 'com.nytimes.android:filesystem3:3.0.0-alpha'
+    implementation 'com.nytimes.android:store3:3.0.0-beta'
+    implementation 'com.nytimes.android:cache3:3.0.0-beta'
+    implementation 'com.nytimes.android:middleware3:3.0.0-beta'
+    implementation 'com.nytimes.android:filesystem3:3.0.0-beta'
     implementation libraries.rxAndroid2
 }


### PR DESCRIPTION
Latest travis build for feature/rx2 was failing after the gradle upgrade. This PR is attempting to get Travis to accept the new build tools license, as well as bumping the sample app up to the latest 3.0.0-beta. 