### PR TITLE
Changed weird MemoryPolicy to 24 hours

### DIFF
--- a/store/src/main/java/com/nytimes/android/external/store3/util/NoopPersister.java
+++ b/store/src/main/java/com/nytimes/android/external/store3/util/NoopPersister.java
@@ -38,8 +38,8 @@ public class NoopPersister<Raw, Key> implements Persister<Raw, Key>, Clearable<K
         if (memoryPolicy == null) {
             memPolicy = MemoryPolicy
                 .builder()
-                .setExpireAfterWrite(TimeUnit.HOURS.toSeconds(24))
-                .setExpireAfterTimeUnit(TimeUnit.SECONDS)
+                .setExpireAfterWrite(24)
+                .setExpireAfterTimeUnit(TimeUnit.HOURS)
                 .build();
         } else {
             memPolicy = memoryPolicy;


### PR DESCRIPTION
I don't know why it was designed like that but the current implementation looks just strange to me.
Moving 24 hours to seconds and set the TimeUnit to seconds..

Why not just directly use HOURS? 🤔  😄 