### PR TITLE
Fix a typo in the documentation

### DIFF
--- a/store-kotlin/src/main/kotlin/com/nytimes/android/external/store3/base/impl/StoreParameters.kt
+++ b/store-kotlin/src/main/kotlin/com/nytimes/android/external/store3/base/impl/StoreParameters.kt
@@ -7,7 +7,7 @@ import com.nytimes.android.external.store3.base.Persister
 import com.nytimes.android.external.store3.util.KeyParser
 
 /**
- * A parameter box for Store instantiation, used for Stores the do not make use of parsing.
+ * A parameter box for Store instantiation, used for Stores that do not make use of parsing.
  * @param fetcher The fetcher for the Store.
  */
 @Experimental


### PR DESCRIPTION
Also, if I may the chance to ask - I've been using store-kotlin myself for a while now without any issues, nor have others raised any afaik, and it has an acceptable amount of tests imho. What else would be needed to decide that those `@Experimental` annotations can be taken out?