### PR TITLE
Add missing reading of expire-after-policy when creating a NoopPersister

### DIFF
--- a/store/src/main/java/com/nytimes/android/external/store3/base/impl/MemoryPolicy.java
+++ b/store/src/main/java/com/nytimes/android/external/store3/base/impl/MemoryPolicy.java
@@ -64,6 +64,14 @@ public class MemoryPolicy {
         return expireAfterWrite == DEFAULT_POLICY;
     }
 
+    public boolean hasWritePolicy() {
+        return expireAfterWrite != DEFAULT_POLICY;
+    }
+
+    public boolean hasAccessPolicy() {
+        return expireAfterAccess != DEFAULT_POLICY;
+    }
+
     public static class MemoryPolicyBuilder {
         private long expireAfterWrite = DEFAULT_POLICY;
         private long expireAfterAccess = DEFAULT_POLICY;

--- a/store/src/main/java/com/nytimes/android/external/store3/base/impl/MemoryPolicy.java
+++ b/store/src/main/java/com/nytimes/android/external/store3/base/impl/MemoryPolicy.java
@@ -60,8 +60,20 @@ public class MemoryPolicy {
         return maxSize;
     }
 
+    /**
+     * @deprecated Use {@link MemoryPolicy#isDefaultWritePolicy()} or {@link MemoryPolicy#isDefaultAccessPolicy()}.
+     */
+    @Deprecated
     public boolean isDefaultPolicy() {
         return expireAfterWrite == DEFAULT_POLICY;
+    }
+
+    public boolean isDefaultWritePolicy() {
+        return expireAfterWrite == DEFAULT_POLICY;
+    }
+
+    public boolean isDefaultAccessPolicy() {
+        return expireAfterAccess == DEFAULT_POLICY;
     }
 
     public boolean hasWritePolicy() {

--- a/store/src/main/java/com/nytimes/android/external/store3/util/NoopParserFunc.java
+++ b/store/src/main/java/com/nytimes/android/external/store3/util/NoopParserFunc.java
@@ -11,6 +11,7 @@ public class NoopParserFunc<Raw, Parsed> implements Parser<Raw, Parsed> {
 
     @Override
     public Parsed apply(@NonNull Raw raw) throws ParserException {
+        //noinspection unchecked
         return (Parsed) raw;
     }
 }

--- a/store/src/main/java/com/nytimes/android/external/store3/util/NoopPersister.java
+++ b/store/src/main/java/com/nytimes/android/external/store3/util/NoopPersister.java
@@ -38,20 +38,15 @@ public class NoopPersister<Raw, Key> implements Persister<Raw, Key>, Clearable<K
     }
 
     public static <Raw, Key> NoopPersister<Raw, Key> create(MemoryPolicy memoryPolicy) {
-        //For some reason PMD requires a local variable instead of modifying the passed one.
-        MemoryPolicy memPolicy;
-
         if (memoryPolicy == null) {
-            memPolicy = MemoryPolicy
+            MemoryPolicy defaultPolicy = MemoryPolicy
                 .builder()
                 .setExpireAfterWrite(24)
                 .setExpireAfterTimeUnit(TimeUnit.HOURS)
                 .build();
-        } else {
-            memPolicy = memoryPolicy;
+            return new NoopPersister<>(defaultPolicy);
         }
-
-        return new NoopPersister<>(memPolicy);
+        return new NoopPersister<>(memoryPolicy);
     }
 
     @Nonnull

--- a/store/src/main/java/com/nytimes/android/external/store3/util/NoopPersister.java
+++ b/store/src/main/java/com/nytimes/android/external/store3/util/NoopPersister.java
@@ -7,12 +7,10 @@ import com.nytimes.android.external.store3.base.Persister;
 import com.nytimes.android.external.store3.base.impl.MemoryPolicy;
 
 import java.util.concurrent.TimeUnit;
-
 import javax.annotation.Nonnull;
 
 import io.reactivex.Maybe;
 import io.reactivex.Single;
-
 
 /**
  * Pass-through diskdao for stores that don't want to use persister
@@ -21,10 +19,18 @@ public class NoopPersister<Raw, Key> implements Persister<Raw, Key>, Clearable<K
     protected final Cache<Key, Maybe<Raw>> networkResponses;
 
     NoopPersister(MemoryPolicy memoryPolicy) {
-        this.networkResponses = CacheBuilder
-            .newBuilder()
-            .expireAfterWrite(memoryPolicy.getExpireAfterWrite(), memoryPolicy.getExpireAfterTimeUnit())
-            .build();
+        if (memoryPolicy.hasAccessPolicy()) {
+            networkResponses = CacheBuilder.newBuilder()
+                .expireAfterAccess(memoryPolicy.getExpireAfterAccess(), memoryPolicy.getExpireAfterTimeUnit())
+                .build();
+
+        } else if (memoryPolicy.hasWritePolicy()) {
+            networkResponses = CacheBuilder.newBuilder()
+                .expireAfterWrite(memoryPolicy.getExpireAfterWrite(), memoryPolicy.getExpireAfterTimeUnit())
+                .build();
+        } else {
+            throw new IllegalArgumentException("No expiry policy set on memory-policy.");
+        }
     }
 
     public static <Raw, Key> NoopPersister<Raw, Key> create() {

--- a/store/src/test/java/com/nytimes/android/external/store3/base/impl/MemoryPolicyBuilderTest.java
+++ b/store/src/test/java/com/nytimes/android/external/store3/base/impl/MemoryPolicyBuilderTest.java
@@ -16,7 +16,7 @@ public class MemoryPolicyBuilderTest {
 
         assertThat(policy.getExpireAfterWrite()).isEqualTo(4L);
         assertThat(policy.getExpireAfterTimeUnit()).isEqualTo(TimeUnit.SECONDS);
-        assertThat(policy.isDefaultPolicy()).isFalse();
+        assertThat(policy.isDefaultWritePolicy()).isFalse();
         assertThat(policy.getExpireAfterAccess()).isEqualTo(MemoryPolicy.DEFAULT_POLICY);
     }
 
@@ -28,7 +28,7 @@ public class MemoryPolicyBuilderTest {
 
         assertThat(policy.getExpireAfterAccess()).isEqualTo(4L);
         assertThat(policy.getExpireAfterTimeUnit()).isEqualTo(TimeUnit.SECONDS);
-        assertThat(policy.isDefaultPolicy()).isTrue();
+        assertThat(policy.isDefaultWritePolicy()).isTrue();
         assertThat(policy.getExpireAfterWrite()).isEqualTo(MemoryPolicy.DEFAULT_POLICY);
     }
 

--- a/store/src/test/java/com/nytimes/android/external/store3/util/NoopPersisterTest.java
+++ b/store/src/test/java/com/nytimes/android/external/store3/util/NoopPersisterTest.java
@@ -1,17 +1,22 @@
 package com.nytimes.android.external.store3.util;
 
 import com.nytimes.android.external.store3.base.impl.BarCode;
+import com.nytimes.android.external.store3.base.impl.MemoryPolicy;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import java.util.concurrent.TimeUnit;
 
 public class NoopPersisterTest {
 
-    private final BarCode barCode = new BarCode("key", "value");
+    @Rule public ExpectedException exception = ExpectedException.none();
 
     @Test
     public void writeReadTest() {
+        BarCode barCode = new BarCode("key", "value");
         NoopPersister<String, BarCode> persister = NoopPersister.create();
         boolean success = persister.write(barCode, "foo").blockingGet();
         assertThat(success).isTrue();
@@ -23,10 +28,32 @@ public class NoopPersisterTest {
     public void noopParserFuncTest() {
         NoopParserFunc<String, String> noopParserFunc = new NoopParserFunc<>();
         String input = "foo";
-        String output = (String) noopParserFunc.apply(input);
+        String output = noopParserFunc.apply(input);
         assertThat(input).isEqualTo(output);
         //intended object ref comparison
         assertThat(input).isSameAs(output);
     }
 
+    // https://github.com/NYTimes/Store/issues/312
+    @Test
+    public void testReadingOfMemoryPolicies() {
+        MemoryPolicy expireAfterWritePolicy = MemoryPolicy.builder()
+            .setExpireAfterWrite(1)
+            .setExpireAfterTimeUnit(TimeUnit.HOURS)
+            .build();
+        NoopPersister.create(expireAfterWritePolicy);
+
+        MemoryPolicy expireAfterAccessPolicy = MemoryPolicy.builder()
+            .setExpireAfterAccess(1)
+            .setExpireAfterTimeUnit(TimeUnit.HOURS)
+            .build();
+        NoopPersister.create(expireAfterAccessPolicy);
+
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("No expiry policy set");
+        MemoryPolicy incompletePolicy = MemoryPolicy.builder()
+            .setExpireAfterTimeUnit(TimeUnit.HOURS)
+            .build();
+        NoopPersister.create(incompletePolicy);
+    }
 }


### PR DESCRIPTION
Fixes #312. I couldn't figure out a way to ensure the memory policies are used while creating cache in `NoopPersister` though.

I also made small style changes. Feel free to ask me to remove them if you want.