### PR TITLE
Remove Deprecated annotation for stream(V key)

### DIFF
--- a/buildsystem/dependencies.gradle
+++ b/buildsystem/dependencies.gradle
@@ -2,10 +2,6 @@ allprojects {
     repositories {
         mavenLocal()
         maven {
-            url 'https://plugins.gradle.org/m2/'
-        }
-
-        maven {
             url = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
         }
         google()

--- a/store/src/main/java/com/nytimes/android/external/store3/base/impl/Store.java
+++ b/store/src/main/java/com/nytimes/android/external/store3/base/impl/Store.java
@@ -69,7 +69,6 @@ public interface Store<T, V> {
      * Errors will be dropped
      *
      */
-    @Deprecated
     @Nonnull
     Observable<T> stream(V key);
 


### PR DESCRIPTION
PR removes `Deprecated` from '@Nonnull Observable<T> stream(V key)' which was undeprecated in https://github.com/NYTimes/Store/pull/252.