### PR TITLE
Update SDK, build tools, gradle, AGP, Kotlin, and library dependencies.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ android:
   components:
   - tools
   - platform-tools
-  - build-tools-27.0.3
-  - android-27
+  - build-tools-28.0.3
+  - android-28
   - extra-android-m2repository
   licenses:
   - 'android-sdk-license-.+'
@@ -15,7 +15,7 @@ script:
 after_success:
   - gradle/deploy_snapshot.sh
 before_install:
-- yes | sdkmanager "platforms;android-27"
+- yes | sdkmanager "platforms;android-28"
 branches:
   except:
   - gh-pages

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     implementation project(':middleware')
     implementation project(':filesystem')
     implementation libraries.rxAndroid2
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$versions.kotlin"
 
     implementation "android.arch.persistence.room:runtime:$room_version"
     annotationProcessor "android.arch.persistence.room:compiler:$room_version"

--- a/build.gradle
+++ b/build.gradle
@@ -2,9 +2,8 @@ apply from: 'buildsystem/dependencies.gradle'
 
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = '1.2.41'
     repositories {
-        mavenLocal()
+        mavenCentral()
         maven {
             url 'https://plugins.gradle.org/m2/'
         }
@@ -19,17 +18,16 @@ buildscript {
     }
 
     rootProject.ext.versions = [
-        kotlin: '1.2.21'
+        kotlin: '1.3.0'
     ]
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.0-alpha16'
-        classpath 'com.google.gms:google-services:3.0.0'
-        classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:0.5.6'
+        classpath 'com.android.tools.build:gradle:3.4.0-alpha02'
+        classpath 'com.google.gms:google-services:4.2.0'
+        classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:0.8.4'
         classpath 'net.ltgt.gradle:gradle-errorprone-plugin:0.0.11'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$rootProject.ext.versions.kotlin"
-        classpath 'org.jetbrains.dokka:dokka-gradle-plugin:0.9.16'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath 'org.jetbrains.dokka:dokka-gradle-plugin:0.9.17'
     }
 }
 

--- a/buildsystem/dependencies.gradle
+++ b/buildsystem/dependencies.gradle
@@ -11,31 +11,31 @@ allprojects {
 
 ext.versions = [
         minSdk               : 16,
-        targetSdk            : 27,
-        compileSdk           : 27,
-        buildTools           : '27.0.3',
-        kotlin               : '1.1.2-5',
+        targetSdk            : 28,
+        compileSdk           : 28,
+        buildTools           : '28.0.3',
+        kotlin               : '1.3.0',
 
         // UI libs.
-        supportLibs          : '27.1.0',
+        supportLibs          : '28.0.0',
         picasso              : '2.5.2',
-        butterKnife          : '7.0.1',
+        butterKnife          : '8.8.1',
 
         // Reactive.
-        rxJava2              : '2.1.2',
-        rxJavaProGuardRules  : '1.1.6.0',
+        rxJava2              : '2.2.3',
+        rxJavaProGuardRules  : '1.3.0.0',
         rxJavaAsyncUtil      : '0.21.0',
-        rxAndroid2           : '2.0.1',
+        rxAndroid2           : '2.1.0',
 
         // Others.
-        retrofit             : '2.2.0',
-        dagger               : '2.9',
-        jsr305               : '3.0.1',
-        okHttp               : '2.7.5',
-        okio                 : '1.13.0',
-        gson                 : '2.8.1',
-        moshi                : '1.5.0',
-        jackson              : '2.8.8',
+        retrofit             : '2.4.0',
+        dagger               : '2.18',
+        jsr305               : '3.0.2',
+        okHttp               : '3.11.0',
+        okio                 : '1.16.0',
+        gson                 : '2.8.5',
+        moshi                : '1.7.0',
+        jackson              : '2.9.7',
         guava                : '19.0',
         javapoet             : '1.8.0',
         immutables           : '2.2.1',

--- a/cache/README.md
+++ b/cache/README.md
@@ -28,7 +28,7 @@ memCache.get(key, new Callable<T>() {
  https://github.com/google/guava/wiki/CachesExplained
 
 ```groovy
-	compile 'com.nytimes.android:cache3:3.0.0-beta'
+	implementation 'com.nytimes.android:cache3:3.0.0-beta'
 ```
 
 ```

--- a/docs/ru/README.md
+++ b/docs/ru/README.md
@@ -333,32 +333,32 @@ public class SampleStore extends RealStore<String, BarCode> {
 + **Cache** Кэш, извлеченный из библиотеки Guava (чтобы сократить количество методов)
 
 	```groovy
-	compile 'com.nytimes.android:cache:CurrentVersion'
+	implementation 'com.nytimes.android:cache:CurrentVersion'
 	```
 + **Store** Содержит только классы Store, зависит от RxJava и артефакта кэша  
 
 	```groovy
-	compile 'com.nytimes.android:store:CurrentVersion'
+	implementation 'com.nytimes.android:store:CurrentVersion'
 	```
 + **Middleware** Парсеры Gson (не стесняйтесь создавать новые и предлагать PR)
 
     ```groovy
-    compile 'com.nytimes.android:middleware:CurrentVersion'
+    implementation 'com.nytimes.android:middleware:CurrentVersion'
     ```
 + **Middleware-Jackson** Парсеры Jackson (не стесняйтесь создавать новые и предлагать PR)
 
     ```groovy
-    compile 'com.nytimes.android:middleware-jackson:CurrentVersion'
+    implementation 'com.nytimes.android:middleware-jackson:CurrentVersion'
     ```
 + **Middleware-Moshi** Парсеры Moshi (не стесняйтесь создавать новые и предлагать PR)
 
     ```groovy
-    compile 'com.nytimes.android:middleware-moshi:CurrentVersion'
+    implementation 'com.nytimes.android:middleware-moshi:CurrentVersion'
     ```
 + **File System** библиотека, использующая Okio Source/Sink + Middleware для сохранения потока данных из сети в файловую систему 
 
 	```groovy
-	compile 'com.nytimes.android:filesystem:CurrentVersion'
+	implementation 'com.nytimes.android:filesystem:CurrentVersion'
 	```
 
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip


### PR DESCRIPTION
PR updates the following:

- Target and Compile SDK: 28
- Build tools: 28.0.3
- Gradle: 4.10.2
- AGP: 3.4.0-alpha02
- dexcount-gradle-plugin: 0.8.4
- google-services plugin: 4.2.0
- dokka-gradle-plugin:0.9.17
- Kotlin: 1.3
- Support library: 28.0.0
- RxJava: 2.2.3
- RxAndroid: 2.1.0
- rxJavaProGuardRules: 1.3.0.0
- ButterKinfe: 8.8.1
- retrofit: 2.4.0
- dagger: 2.18
- jsr305: 3.0.2
- okHttp: 3.11.0
- okio: 1.16.0
- gson: 2.8.5
- moshi: 1.7.0
- jackson: 2.9.7

This should also (hopefully) fix the failing CI.