### PR TITLE
Clarify required dependencies for Store-Kotlin in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ public class SampleStore extends RealStore<String, BarCode> {
 + **Store-Kotlin** Store plus a couple of added Kotlin classes for more idiomatic usage.
 
     ```groovy
+    implementation 'com.nytimes.android:store3:CurrentVersion'
     implementation 'com.nytimes.android:store-kotlin3:CurrentVersion'
     ```
     


### PR DESCRIPTION
Prior to AGP 3.3.x, only declaring the `implementation 'com.nytimes.android:store-kotlin3:CurrentVersion'` is enough as the required store classes in the core `store` module are also brought in.

Since AGP 3.3.x this no longer works as classes in the `com.nytimes.android:store3` artifact can't be resolved unless adding `implementation 'com.nytimes.android:store3:CurrentVersion'` alongside the Kotlin dependency.

PR adds `implementation 'com.nytimes.android:store3:CurrentVersion'` in README.md for **Store-Kotlin**

Question: was `com.nytimes.android:store-kotlin3:CurrentVersion` intended to also bring in the `com.nytimes.android:store3` dependency for the consuming module? If that's the case should we change `apiElements project(':store')` to `api project(':store')` in `store-kotlin/build.gradle`?