### PR TITLE
Fix store-kotlin module's store dependency

### DIFF
--- a/store-kotlin/build.gradle
+++ b/store-kotlin/build.gradle
@@ -15,7 +15,7 @@ javadoc.dependsOn dokka
 
 dependencies {
     implementation project(':store')
-    apiElements project(':store')
+    api project(':store')
     implementation libraries.kotlinStdLib
     apiElements libraries.kotlinStdLib
 


### PR DESCRIPTION
As discussed and suggested in https://github.com/NYTimes/Store/pull/376, the `store` dependency in `store-kotlin/build.gradle` should be `api project(':store')` instead of  `apiElements project(':store')` as `store` should be exposed to consumer so explicitly declaring `implementation 'com.nytimes.android:store3:CurrentVersion'` alongside `implementation 'com.nytimes.android:store-kotlin3:CurrentVersion'` is no longer required .

Before:
```
implementation 'com.nytimes.android:store-kotlin3:CurrentVersion'
implementation 'com.nytimes.android:store3:CurrentVersion'
```

After:
```
implementation 'com.nytimes.android:store-kotlin3:CurrentVersion'
```