### PR TITLE
Stop caching all Room responses

### DIFF
--- a/store/src/main/java/com/nytimes/android/external/store3/base/impl/room/RealStoreRoom.java
+++ b/store/src/main/java/com/nytimes/android/external/store3/base/impl/room/RealStoreRoom.java
@@ -114,7 +114,7 @@ class RealStoreRoom<Raw, Parsed, Key> extends StoreRoom<Parsed, Key> {
                             && StoreUtil.persisterIsStale(key, persister)) {
                         backfillCache(key);
                     }
-                }).cache();
+                }).replay(1);
     }
 
     @SuppressWarnings("CheckReturnValue")
@@ -170,7 +170,7 @@ class RealStoreRoom<Raw, Parsed, Key> extends StoreRoom<Parsed, Key> {
                     return Observable.error(throwable);
                 })
                 .doAfterTerminate(() -> inFlightRequests.invalidate(key))
-                .cache();
+                .replay(1);
     }
 
 


### PR DESCRIPTION
Currently if a user subscribes to a StoreRoom that has emitted 100 collections of items from a room db, it would get all the emissions. This pr changes to only send through the last value