### PR TITLE
Fix link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Store is a Java library for effortless, reactive data loading.
 + Users expect their UI experience to never be compromised (blocked) by new data loads. Whether an application is social, news, or business-to-business, users expect a seamless experience both online and offline.
 + International users expect minimal data downloads as many megabytes of downloaded data can quickly result in astronomical phone bills.
 
-A Store is a class that simplifies fetching, parsing, storage, and retrieval of data in your application. A Store is similar to the Repository pattern [[https://msdn.microsoft.com/en-us/library/ff649690.aspx](https://msdn.microsoft.com/en-us/library/ff649690.aspx)] while exposing a Reactive API built with [RxJava](https://github.com/ReactiveX/RxJava) that adheres to a unidirectional data flow.
+A Store is a class that simplifies fetching, parsing, storage, and retrieval of data in your application. A Store is similar to the [Repository pattern](https://msdn.microsoft.com/en-us/library/ff649690.aspx)] while exposing a Reactive API built with [RxJava](https://github.com/ReactiveX/RxJava) that adheres to a unidirectional data flow.
 
 Store provides a level of abstraction between UI elements and data operations.
 


### PR DESCRIPTION
The link for the "Repository pattern" was not the same format as the link for "RxJava" just two sentences later. This is more legible and less distracting.